### PR TITLE
Create parent type on document signature sent type

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Office Service (SIKD) 
 
+<a href="https://codeclimate.com/github/jabardigitalservice/office-services/maintainability"><img src="https://api.codeclimate.com/v1/badges/888efd380ccef5a509cd/maintainability" /></a>
 ## Overview
 This service is used by [Office Mobile (Flutter)](https://github.com/jabardigitalservice/office-mobile).
 

--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -36,6 +36,14 @@ class DocumentSignatureMutator
             throw new CustomException('User already signed this document', 'Status of this document is already signed');
         }
 
+        $checkParent = DocumentSignatureSent::where('ttd_id', $documentSignatureSent->ttd_id)
+            ->where('urutan', $documentSignatureSent->urutan - 1)
+            ->first();
+
+        if ($checkParent && $checkParent->status != SignatureStatusTypeEnum::SUCCESS()->value) {
+            throw new CustomException('Parent user is not already signed this document', 'Parent user of list signature assign is not already signed');
+        }
+
         $setupConfig = $this->setupConfigSignature();
         $file = $this->fileExist($documentSignatureSent->documentSignature->url);
 

--- a/src/app/GraphQL/Types/DocumentSignatureSentType.php
+++ b/src/app/GraphQL/Types/DocumentSignatureSentType.php
@@ -20,7 +20,6 @@ class DocumentSignatureSentType
         $isLastSigned = DocumentSignatureSent::where('ttd_id', $rootValue->ttd_id)
             ->where('PeopleID', $rootValue->PeopleID)
             ->where('urutan', $rootValue->urutan + 1)
-            ->where('status', 1)
             ->first();
 
         if ($isLastSigned) {

--- a/src/app/GraphQL/Types/DocumentSignatureSentType.php
+++ b/src/app/GraphQL/Types/DocumentSignatureSentType.php
@@ -29,4 +29,26 @@ class DocumentSignatureSentType
 
         return true;
     }
+
+    /**
+     * @param $rootValue
+     * @param array                                                    $args
+     * @param \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null $context
+     *
+     * @return array
+     */
+    public function parent($rootValue, array $args, GraphQLContext $context)
+    {
+        $parent = DocumentSignatureSent::where('ttd_id', $rootValue->ttd_id)
+            ->where('PeopleID', $rootValue->PeopleID)
+            ->where('urutan', $rootValue->urutan - 1)
+            ->where('status', 1)
+            ->first();
+
+        if ($parent) {
+            return $parent;
+        }
+
+        return null;
+    }
 }

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -13,6 +13,7 @@ type DocumentSignatureSent {
     receiver: People!
     read: Boolean @belongsTo(relation: "documentSignatureSentRead")
     isLastSigned: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isLastSigned")
+    parent: DocumentSignatureSent @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@parent")
     documentSignature: DocumentSignature @belongsTo
 }
 


### PR DESCRIPTION
## Overview

- User should be able to see parent data from the detail page document signature sent request sign
- If the `parent` is `not null` & `status = 0`, the user `can not sign` the document
- If the `parent` is `not null` & `status = 4`, the user `can not sign` the document
- If the `parent` is `not null` & `status = 1`, the user will be `allowed to sign` the document
- If the `parent` `is null`, the user will be `allowed to sign` the document

Related Task : https://sharing.clickup.com/t/h/1rx6hcb/70W8POC6Y1JJKXL

## Changes
- Add parent type on `DocumentSignatureSentType`

## Implementation
````
{
    documentSignatureSent(id: $id) {
        id
        ...
        ...
        parent {
            id
            status
            sort
            receiver {
                name
            }
        }
        ...
        ...
        ...
    }
}
````

## Evidence
title: Menambahkan type parent untuk validasi user dapat melakukan tte
project: SIKD
participants: @indraprasetya154 @samudra-ajri