### PR TITLE
Add unread inbox couting

### DIFF
--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -2,9 +2,9 @@
 
 namespace App\GraphQL\Queries;
 
+use App\Enums\InboxReceiverScopeType;
 use App\Exceptions\CustomException;
 use App\Models\InboxReceiver;
-use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class InboxQuery
@@ -51,5 +51,60 @@ class InboxQuery
         }
 
         return true;
+    }
+
+    /**
+     * @param $rootValue
+     * @param array                                                    $args
+     * @param \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null $context
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    public function unreadCount($rootValue, array $args, GraphQLContext $context)
+    {
+        $regionalCount = $this->unreadCountQuery(InboxReceiverScopeType::REGIONAL(), $context);
+        $internalCount = $this->unreadCountQuery(InboxReceiverScopeType::INTERNAL(), $context);
+
+        dd($context);
+
+        $count = [
+            'regional' => $regionalCount,
+            'internal' => $internalCount
+        ];
+
+        return $count;
+    }
+
+    /**
+     * @param String scope
+     * @param \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null $context
+     *
+     * @return Integer
+     */
+    private function unreadCountQuery($scope, GraphQLContext $context)
+    {
+        $user = $context->user;
+        $deptCode = $user->role->RoleCode;
+
+        $operator = '';
+        switch ($scope) {
+            case InboxReceiverScopeType::REGIONAL():
+                $operator = '!=';
+                break;
+
+            case InboxReceiverScopeType::INTERNAL():
+                $operator = '=';
+                break;
+        }
+
+        return InboxReceiver::where('RoleId_To', $user->PrimaryRoleId)
+            ->where('StatusReceive', 'unread')
+            ->whereHas('sender', function($senderQuery) use ($deptCode, $operator) {
+                $senderQuery->whereHas('role', function($roleQuery) use ($deptCode, $operator) {
+                    $roleQuery->where('RoleCode', $operator, $deptCode);
+                });
+            })->count();
     }
 }

--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -67,8 +67,6 @@ class InboxQuery
         $regionalCount = $this->unreadCountQuery(InboxReceiverScopeType::REGIONAL(), $context);
         $internalCount = $this->unreadCountQuery(InboxReceiverScopeType::INTERNAL(), $context);
 
-        dd($context);
-
         $count = [
             'regional' => $regionalCount,
             'internal' => $internalCount

--- a/src/graphql/inbox.graphql
+++ b/src/graphql/inbox.graphql
@@ -17,7 +17,6 @@ type Inbox {
 }
 
 type UnreadCount {
-    toal: Int!
     regional: Int!
     internal: Int!
 }

--- a/src/graphql/inbox.graphql
+++ b/src/graphql/inbox.graphql
@@ -16,6 +16,12 @@ type Inbox {
     documentFile: InboxFile @belongsTo
 }
 
+type UnreadCount {
+    toal: Int!
+    regional: Int!
+    internal: Int!
+}
+
 #import people.graphql
 #import documentType.graphql
 #import documentUrgency.graphql

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -44,6 +44,10 @@ type Query {
         @paginate(type: CONNECTION)
         @guard
 
+    inboxUnreadCount: UnreadCount!
+        @field(resolver: "InboxQuery@unreadCount")
+        @guard
+
     me: People @auth
 
     peopleList(


### PR DESCRIPTION
## Overview
- Add unread inbox counting functionality
- The counters are scoped by REGIONAL and INTERNAL inbox

## Implementation
```
{
  inboxUnreadCount{
    regional
    internal
  }
}
```
__
title: Add unread inbox couting
project: SIKD
participants: @samudra-ajri @indraprasetya154