### PR TITLE
Add Drafts List from Inbox Receiver Correction Table

### DIFF
--- a/src/app/Models/InboxReceiver.php
+++ b/src/app/Models/InboxReceiver.php
@@ -83,11 +83,6 @@ class InboxReceiver extends Model
         return $this->belongsTo(InboxDisposition::class, 'GIR_Id', 'GIR_Id');
     }
 
-    public function draftDetail()
-    {
-        return $this->belongsTo(Draft::class, 'NId', 'NId_Temp');
-    }
-
     public function filter($query, $filter)
     {
         $sources = $filter["sources"] ?? null;

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -49,7 +49,7 @@ class InboxReceiverCorrection extends Model
     public function grouping($query, $grouping)
     {
         if ($grouping) {
-            $query->groupBy('NId')->orderBy('ReceiveDate', 'DESC');
+            $query->distinct('NId');
         }
         return $query;
     }

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class InboxReceiverCorrection extends Model
+{
+    use HasFactory;
+
+    protected $connection = 'sikdweb';
+
+    protected $table = "inbox_receiver_koreksi";
+
+    public $timestamps = false;
+
+    protected $keyType = 'string';
+
+    protected $primaryKey = 'NId';
+
+    public function draftDetail()
+    {
+        return $this->belongsTo(Draft::class, 'NId', 'NId_Temp');
+    }
+
+    public function sender()
+    {
+        return $this->belongsTo(People::class, 'From_Id', 'PeopleId');
+    }
+
+    public function receiver()
+    {
+        return $this->belongsTo(People::class, 'To_Id', 'PeopleId');
+    }
+}

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -33,4 +33,15 @@ class InboxReceiverCorrection extends Model
     {
         return $this->belongsTo(People::class, 'To_Id', 'PeopleId');
     }
+
+    public function search($query, $search)
+    {
+        $query->whereIn('NId', function ($inboxQuery) use ($search) {
+            $inboxQuery->select('NId_Temp')
+                ->from('konsep_naskah')
+                ->where('Hal', 'LIKE', '%' . $search . '%');
+        });
+
+        return $query;
+    }
 }

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\DB;
 
 class InboxReceiverCorrection extends Model
 {
@@ -42,6 +43,14 @@ class InboxReceiverCorrection extends Model
                 ->where('Hal', 'LIKE', '%' . $search . '%');
         });
 
+        return $query;
+    }
+
+    public function grouping($query, $grouping)
+    {
+        if ($grouping) {
+            $query->groupBy('NId')->orderBy('ReceiveDate', 'DESC');
+        }
         return $query;
     }
 }

--- a/src/graphql/inboxReceiver.graphql
+++ b/src/graphql/inboxReceiver.graphql
@@ -18,7 +18,6 @@ type InboxReceiver {
     receiver: People @belongsTo
     inboxDisposition: InboxDisposition @belongsTo
     isEndForward: Boolean @field(resolver: "App\\GraphQL\\Types\\InboxReceiverType@isEndForward")
-    draftDetail: Draft @belongsTo
 }
 
 input FilterInput {
@@ -49,4 +48,3 @@ enum ScopeType {
 #import inbox.graphql
 #import people.graphql
 #import inboxDisposition.graphql
-#import draft.graphql

--- a/src/graphql/inboxReceiverCorrection.graphql
+++ b/src/graphql/inboxReceiverCorrection.graphql
@@ -1,0 +1,16 @@
+type InboxReceiverCorrection {
+    draftId: String! @rename(attribute: "NId")
+    groupId: String! @rename(attribute: "GIR_Id")
+    date: DateTime! @rename(attribute: "ReceiveDate")
+    fromId: Int @rename(attribute: "From_Id")
+    toId: String @rename(attribute: "To_Id")
+    message: String @rename(attribute: "Msg")
+    receiverAs: String @rename(attribute: "ReceiverAs")
+    receiveStatus: String @rename(attribute: "StatusReceive")
+    toIdDesc: String @rename(attribute: "To_Id_Desc")
+    isActioned: Int @rename(attribute: "Status")
+    correctionId: String @rename(attribute: "id_koreksi")
+    draftDetail: Draft @belongsTo
+}
+
+#import draft.graphql

--- a/src/graphql/inboxReceiverCorrection.graphql
+++ b/src/graphql/inboxReceiverCorrection.graphql
@@ -11,6 +11,10 @@ type InboxReceiverCorrection {
     isActioned: Int @rename(attribute: "Status")
     correctionId: String @rename(attribute: "id_koreksi")
     draftDetail: Draft @belongsTo
+    sender: People @belongsTo
+    receiver: People @belongsTo
 }
 
 #import draft.graphql
+#import people.graphql
+

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -96,9 +96,11 @@ type Query {
         @guard
 
     drafts(
+        grouping: Boolean @builder(method: "App\\Models\\InboxReceiverCorrection@grouping")
         search: String @builder(method: "App\\Models\\InboxReceiverCorrection@search")
     ): [InboxReceiverCorrection!]!
         @whereAuth(relation: "receiver")
+        @orderBy(column: "ReceiveDate", direction: DESC)
         @paginate(type: CONNECTION)
         @guard
 }

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -95,7 +95,9 @@ type Query {
         @field(resolver: "DocumentSignatureHistoryQuery@history")
         @guard
 
-    drafts: [InboxReceiverCorrection!]!
+    drafts(
+        search: String @builder(method: "App\\Models\\InboxReceiverCorrection@search")
+    ): [InboxReceiverCorrection!]!
         @whereAuth(relation: "receiver")
         @paginate(type: CONNECTION)
         @guard

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -94,6 +94,11 @@ type Query {
     ): DocumentSignatureSentHistory
         @field(resolver: "DocumentSignatureHistoryQuery@history")
         @guard
+
+    drafts: [InboxReceiverCorrection!]!
+        @whereAuth(relation: "receiver")
+        @paginate(type: CONNECTION)
+        @guard
 }
 
 type Mutation {
@@ -124,4 +129,4 @@ type Mutation {
 #import documentSignature.graphql
 #import documentSignatureForward.graphql
 #import masterDisposition.graphql
-#import draft.graphql
+#import inboxReceiverCorrection.graphql


### PR DESCRIPTION
## Overview
- Add `InboxReceiverCorrection` model to acomodate the drafts list
- Add grouping filter for grouping the drafts list by its `NId` and gets the latest as the result

## Implementation
```
{
  drafts(
    first: 10
    grouping: true
  ){
    pageInfo{
      total
    }
    edges{
      node{
        sender{
          name
        }
        receiver{
          name
        }
        draftDetail{
          id
          date
          receiverAs
          number
          letterNumber
          about
          moreAbout
          location
          address
          folder
          type{
            id
            name
          }
          urgency{
            id
            name
          }
          createdBy{
            id
            name
          }
          reviewer{
            id
            name
          }
        }
        draftId
        groupId
        date
        fromId
        toId
        message
        receiverAs
        receiveStatus
        toIdDesc
        isActioned
        correctionId
      }
    }
  }
}
```
__
title: Add Drafts List from Inbox Receiver Correction Table
project: SIKD
participants: @samudra-ajri @indraprasetya154