### PR TITLE
User should be able to see detail draft

### DIFF
--- a/src/app/GraphQL/Queries/DraftQuery.php
+++ b/src/app/GraphQL/Queries/DraftQuery.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\GraphQL\Queries;
+
+use App\Exceptions\CustomException;
+use App\Models\InboxReceiverCorrection;
+use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
+
+class DraftQuery
+{
+    /**
+     * @param $rootValue
+     * @param array                                                    $args
+     * @param \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null $context
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    public function detail($rootValue, array $args, GraphQLContext $context)
+    {
+        $inboxReceiverCorrection = tap(InboxReceiverCorrection::where('NId', $args['draftId'])
+                                                        ->where('GIR_Id', $args['groupId']))
+                                                        ->update(['StatusReceive' => 'read'])
+                                                        ->first();
+
+        if (!$inboxReceiverCorrection) {
+            throw new CustomException(
+                'Draft not found',
+                'Draft with this NId not found'
+            );
+        }
+
+        return $inboxReceiverCorrection;
+    }
+}

--- a/src/app/GraphQL/Queries/DraftQuery.php
+++ b/src/app/GraphQL/Queries/DraftQuery.php
@@ -19,10 +19,11 @@ class DraftQuery
      */
     public function detail($rootValue, array $args, GraphQLContext $context)
     {
-        $inboxReceiverCorrection = tap(InboxReceiverCorrection::where('NId', $args['draftId'])
-                                                        ->where('GIR_Id', $args['groupId']))
-                                                        ->update(['StatusReceive' => 'read'])
+        $inboxReceiverCorrection = InboxReceiverCorrection::where('NId', $args['draftId'])
+                                                        ->where('GIR_Id', $args['groupId'])
                                                         ->first();
+        $inboxReceiverCorrection->StatusReceive = 'read';
+        $inboxReceiverCorrection->save();
 
         if (!$inboxReceiverCorrection) {
             throw new CustomException(

--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -20,7 +20,9 @@ class InboxQuery
      */
     public function detail($rootValue, array $args, GraphQLContext $context)
     {
-        $inboxReceiver = InboxReceiver::where('id', $args['id'])->first();
+        $inboxReceiver = tap(InboxReceiver::where('id', $args['id']))
+                                        ->update(['StatusReceive' => 'read'])
+                                        ->first();
 
         if (!$inboxReceiver) {
             throw new CustomException(
@@ -29,28 +31,7 @@ class InboxQuery
             );
         }
 
-        //Check the inbox is readed or not
-        $this->markAsRead($inboxReceiver, $context);
-
         return $inboxReceiver;
-    }
-
-    /**
-     * markAsRead
-     *
-     * @param Object $inboxReceiver
-     * @param Object $context
-     *
-     * @return boolean
-     */
-    public function markAsRead($inboxReceiver, $context)
-    {
-        if ($inboxReceiver->StatusReceive != 'read') {
-            InboxReceiver::where('id', $inboxReceiver->id)
-                        ->update(['StatusReceive' => 'read']);
-        }
-
-        return true;
     }
 
     /**

--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -20,9 +20,9 @@ class InboxQuery
      */
     public function detail($rootValue, array $args, GraphQLContext $context)
     {
-        $inboxReceiver = tap(InboxReceiver::where('id', $args['id']))
-                                        ->update(['StatusReceive' => 'read'])
-                                        ->first();
+        $inboxReceiver = InboxReceiver::find($args['id']);
+        $inboxReceiver->StatusReceive = 'read';
+        $inboxReceiver->save();
 
         if (!$inboxReceiver) {
             throw new CustomException(

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -103,6 +103,13 @@ type Query {
         @orderBy(column: "ReceiveDate", direction: DESC)
         @paginate(type: CONNECTION)
         @guard
+
+    draft(
+        draftId: String!
+        groupId: String!
+    ): InboxReceiverCorrection
+        @field(resolver: "DraftQuery@detail")
+        @guard
 }
 
 type Mutation {


### PR DESCRIPTION
## Overview

- User should be able to see a detailed draft

## Changes
- Add `DraftQuery` to handle change read status

## Implementation
````
{
  draft(
    draftId: $draftId,
    groupId: $groupId,
  ){
    sender{
      name
    }
    receiver{
      id
      name
    }
    draftId
    groupId
    date
    fromId
    toId
    message
    receiverAs
    receiveStatus
    toIdDesc
    isActioned
    correctionId
    draftDetail {
      about
		}
  }
}
````

## Evidence
title: User dapat melihat detail konsep naskah
project: SIKD
participants: @indraprasetya154 @samudra-ajri @ayocodingit 