### PR TITLE
User should be able to see people timeline draft

### DIFF
--- a/src/app/GraphQL/Queries/DraftQuery.php
+++ b/src/app/GraphQL/Queries/DraftQuery.php
@@ -4,6 +4,7 @@ namespace App\GraphQL\Queries;
 
 use App\Exceptions\CustomException;
 use App\Models\InboxReceiverCorrection;
+use Illuminate\Support\Arr;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class DraftQuery
@@ -33,5 +34,28 @@ class DraftQuery
         }
 
         return $inboxReceiverCorrection;
+    }
+
+    /**
+     * @param $rootValue
+     * @param array                                                    $args
+     * @param \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null $context
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    public function timeline($rootValue, array $args, GraphQLContext $context)
+    {
+        $draftId = Arr::get($args, 'filter.draftId');
+        $type = Arr::get($args, 'filter.type');
+
+        $inboxReceiverCorrections = InboxReceiverCorrection::where('NId', $draftId)
+                                                            ->where('ReceiverAs', $type)
+                                                            ->orderBy('ReceiveDate', 'desc')
+                                                            ->get()
+                                                            ->unique('To_Id');
+
+        return $inboxReceiverCorrections;
     }
 }

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Enums\InboxReceiverCorrectionReceiverTypeEnum;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -2,9 +2,9 @@
 
 namespace App\Models;
 
+use App\Enums\InboxReceiverCorrectionReceiverTypeEnum;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\DB;
 
 class InboxReceiverCorrection extends Model
 {

--- a/src/graphql/inboxReceiverCorrection.graphql
+++ b/src/graphql/inboxReceiverCorrection.graphql
@@ -16,7 +16,7 @@ type InboxReceiverCorrection {
 }
 
 enum TimelineType {
-    VERIFICATION @enum(value: "koreksi")
+    CORRECTION @enum(value: "koreksi")
 }
 
 input DraftTimelineInput {

--- a/src/graphql/inboxReceiverCorrection.graphql
+++ b/src/graphql/inboxReceiverCorrection.graphql
@@ -15,6 +15,15 @@ type InboxReceiverCorrection {
     receiver: People @belongsTo
 }
 
+enum TimelineType {
+    VERIFICATION @enum(value: "koreksi")
+}
+
+input DraftTimelineInput {
+    draftId: String!
+    type: TimelineType
+}
+
 #import draft.graphql
 #import people.graphql
 

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -110,6 +110,12 @@ type Query {
     ): InboxReceiverCorrection
         @field(resolver: "DraftQuery@detail")
         @guard
+
+    draftTimeline(
+        filter: DraftTimelineInput @builder(method: "App\\Models\\InboxReceiverCorrection@timeline")
+    ): [InboxReceiverCorrection!]!
+        @field(resolver: "DraftQuery@timeline")
+        @guard
 }
 
 type Mutation {


### PR DESCRIPTION
## Overview

- User should be able to see people timeline draft

## Changes
- Add `DraftQuery@timeline` to see people timeline using `DraftTimelineInput`
- Add `TimelineType` for set type at `DraftTimelineInput`
- `TimelineType` for now have value `VERIFICATION` (koreksi), for get people who's correction the draft

## Implementation
````
{
  draftTimeline(
    filter: {
        draftId: "$id",
        type: CORRECTION
    }
  ){
    sender{
      name
    }
    receiver{
      id
      name
    }
    draftId
    groupId
    date
    fromId
    toId
    message
    receiverAs
    receiveStatus
    toIdDesc
    isActioned
    correctionId
    draftDetail {
      about
    }
  }
}
````

## Evidence
title: User dapat melihat detail konsep naskah
project: SIKD
participants: @indraprasetya154 @samudra-ajri