### PR TITLE
Enhance grouping timeline user by unsigned and signed

### DIFF
--- a/src/app/Enums/SignatureStatusTypeEnum.php
+++ b/src/app/Enums/SignatureStatusTypeEnum.php
@@ -8,6 +8,8 @@ use Spatie\Enum\Enum;
  * @method static self WAITING()
  * @method static self SUCCESS()
  * @method static self REJECT()
+ * @method static self SIGNED()
+ * @method static self UNSIGNED()
  */
 
 class SignatureStatusTypeEnum extends Enum

--- a/src/app/Models/DocumentSignatureSent.php
+++ b/src/app/Models/DocumentSignatureSent.php
@@ -135,8 +135,13 @@ class DocumentSignatureSent extends Model
         $query->where('ttd_id', $documentSignatureId)
             ->where('urutan', '<', $sort);
 
-        if ($status || $status == "0") {
-            $query->where('status', $status);
+        if ($status) {
+            if ($status == SignatureStatusTypeEnum::SIGNED()) {
+                $query->where('status', SignatureStatusTypeEnum::SUCCESS()->value);
+            }
+            if ($status == SignatureStatusTypeEnum::UNSIGNED()) {
+                $query->whereIn('status', [SignatureStatusTypeEnum::WAITING()->value, SignatureStatusTypeEnum::REJECT()->value]);
+            }
         }
 
         return $query;

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -37,9 +37,8 @@ input documentSignatureSentTimelineInput {
 }
 
 enum StatusType {
-    SUCCESS @enum(value: "1")
-    FAILED @enum(value: "4")
-    PENDING @enum(value: "0")
+    SIGNED
+    UNSIGNED
 }
 
 #import people.graphql


### PR DESCRIPTION
## Overview

- User should be able to see grouping timeline people by unsigned and signed

## Changes
- Modify enum value `StatusType` to `SIGNED` and `UNSIGNED`
- Add enum value `SIGNED` and `UNSIGNED` at `SignatureStatusTypeEnum.php`

## Implementation
````
{
  documentSignatureSentTimeline(
    filter: {
    	documentSignatureId:  $documentSignatureId,
        sort: "3"
         status: SIGNED
    }
  ) {
      id
      ....
  }
````

## Evidence
title: Membuat grouping user timeline berdasarkan yang sudah & belum tandatangan dokumen
project: SIKD
participants: @indraprasetya154 @samudra-ajri