### PR TITLE
Add document signature relation with inbox

### DIFF
--- a/src/app/Models/DocumentSignature.php
+++ b/src/app/Models/DocumentSignature.php
@@ -35,4 +35,9 @@ class DocumentSignature extends Model
     {
         return $this->hasMany(DocumentSignatureSent::class, 'ttd_id', 'id');
     }
+
+    public function inboxFile()
+    {
+        return $this->belongsTo(InboxFile::class, 'file', 'FileName_real');
+    }
 }

--- a/src/app/Models/InboxFile.php
+++ b/src/app/Models/InboxFile.php
@@ -24,6 +24,11 @@ class InboxFile extends Model
         return $this->belongsTo(Inbox::class, 'NId', 'NId');
     }
 
+    public function inboxReceiver()
+    {
+        return $this->belongsTo(InboxReceiver::class, 'GIR_Id', 'GIR_Id');
+    }
+
     public function find($query, $id)
     {
         $query->where('Id_dokumen', $id)

--- a/src/graphql/documentSignature.graphql
+++ b/src/graphql/documentSignature.graphql
@@ -3,6 +3,7 @@ type DocumentSignature {
     name: String @rename(attribute: "nama_file")
     url: String
     validation: Validation @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureType@validate")
+    inboxFile: InboxFile @belongsTo
     documentSignatureSents: [DocumentSignatureSent]
 }
 

--- a/src/graphql/inboxFile.graphql
+++ b/src/graphql/inboxFile.graphql
@@ -2,6 +2,7 @@ type InboxFile {
     id: String @rename(attribute: "Id_dokumen")
     name: String @rename(attribute: "FileName_fake")
     inboxDetail: Inbox @belongsTo
+    inboxReceiver: InboxReceiver @belongsTo
     validation: Validation @field(resolver: "App\\GraphQL\\Types\\InboxFileType@validate")
 }
 


### PR DESCRIPTION
## Overview

- User should be able to see the sender and receiver after the document attached in the inbox feature (pencatatan naskah keluar)

## Changes
- Add relation between `DocumentSignature` and `InboxFile`
- Add relation between `InboxFile` and `InboxReceiver`

### Notes
The existing code didn't have a foreign key from `InboxFile` with `DocumentSignature`, so I found field `FileName_real` from `InboxFile` can be relational with `DocumentSignature` field `file`

## Implementation
````
{
  documentSignature(id: $documentSignatureId) {
    id
    name
    url
    inboxFile {
      inboxReceiver {
        sender {
          name
          avatar {
            url
          }
          role {
            name
          }
        }
        receiver {
          name
          avatar {
            url
          }
          role {
            name
          }
        }
      }
    }
    documentSignatureSents {
      id
      signatureId
      peopleId
      to
      date
      note
      status
      ...
    }
  }
}
````

## Evidence
title: Add document signature relation with inbox
project: SIKD
participants: @indraprasetya154 @samudra-ajri