### PR TITLE
Change relation inbox receiver from belongsTo to hasMany

### DIFF
--- a/src/app/Models/InboxFile.php
+++ b/src/app/Models/InboxFile.php
@@ -24,9 +24,9 @@ class InboxFile extends Model
         return $this->belongsTo(Inbox::class, 'NId', 'NId');
     }
 
-    public function inboxReceiver()
+    public function inboxReceivers()
     {
-        return $this->belongsTo(InboxReceiver::class, 'GIR_Id', 'GIR_Id');
+        return $this->hasMany(InboxReceiver::class, 'GIR_Id', 'GIR_Id');
     }
 
     public function find($query, $id)

--- a/src/graphql/inboxFile.graphql
+++ b/src/graphql/inboxFile.graphql
@@ -2,7 +2,7 @@ type InboxFile {
     id: String @rename(attribute: "Id_dokumen")
     name: String @rename(attribute: "FileName_fake")
     inboxDetail: Inbox @belongsTo
-    inboxReceiver: InboxReceiver @belongsTo
+    inboxReceivers: [InboxReceiver] @hasMany
     validation: Validation @field(resolver: "App\\GraphQL\\Types\\InboxFileType@validate")
 }
 


### PR DESCRIPTION
## Overview

- User should be able to see the sender and **receivers/multiple receiver** after the document attached in the inbox feature (pencatatan naskah keluar)

## Changes
- Add relation between `InboxFile` and `InboxReceiver` (**one to many**)

## Implementation

- change from `inboxReceiver` to `inboxReceivers`

````
{
  documentSignature(id: $documentSignatureId) {
    id
    name
    url
    inboxFile {
      inboxReceivers {
        sender {
          name
          avatar {
            url
          }
          role {
            name
          }
        }
        receiver {
          name
          avatar {
            url
          }
          role {
            name
          }
        }
      }
    }
    documentSignatureSents {
      id
      signatureId
      peopleId
      to
      date
      note
      status
      ...
    }
  }
}
````

## Evidence
title: Change document signature relation (one to many) with inbox
project: SIKD
participants: @indraprasetya154 @samudra-ajri