### PR TITLE
Add unread inbox counter for 'Kadis/Sekdis' roles

### DIFF
--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -94,7 +94,7 @@ class InboxQuery
                 });
             });
 
-        if ((String) $user->PeopleId != PeopleGroupTypeEnum::TU()) {
+        if ((String) $user->GroupId != PeopleGroupTypeEnum::TU()) {
             $query->where('To_Id', $user->PeopleId);
         }
 
@@ -113,7 +113,7 @@ class InboxQuery
             ->where('StatusReceive', 'unread')
             ->where('ReceiverAs', 'to_forward');
 
-        if ((String) $user->PeopleId != PeopleGroupTypeEnum::TU()) {
+        if ((String) $user->GroupId != PeopleGroupTypeEnum::TU()) {
             $query->where('To_Id', $user->PeopleId);
         }
 

--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -47,8 +47,14 @@ class InboxQuery
      */
     public function unreadCount($rootValue, array $args, GraphQLContext $context)
     {
-        if (strpos($context->user->PeoplePosition, 'KEPALA DINAS') !== false ||
-            strpos($context->user->PeoplePosition, 'SEKRETARIS DINAS') !== false) {
+        $userPosition = $context->user->PeoplePosition;
+        $positionGroups = array_merge(
+            config('constants.peoplePositionGroups.2'),
+            config('constants.peoplePositionGroups.9')
+        );
+
+        $found = $this->isFoundUserPosition($userPosition, $positionGroups);
+        if ($found) {
             $regionalCount = $this->unreadCountDeptQuery($context);
         } else {
             $regionalCount = $this->unreadCountQuery(InboxReceiverScopeType::REGIONAL(), $context);
@@ -118,5 +124,24 @@ class InboxQuery
         }
 
         return $query->count();
+    }
+
+     /**
+     * @param Array $positionList
+     * @param String $position
+     *
+     * @return Boolean
+     */
+    private function isFoundUserPosition($userPosition, $positionList)
+    {
+        $found = false;
+        foreach ($positionList as $position) {
+            if (strpos($userPosition, $position) !== false) {
+                $found = true;
+                break;
+            }
+        }
+
+        return $found;
     }
 }

--- a/src/config/constants.php
+++ b/src/config/constants.php
@@ -1,0 +1,31 @@
+<?php
+
+return [
+
+    'peoplePositionGroups' => [
+        '2' => array(
+            'WAKIL GUBERNUR',
+            'SEKRETARIS DAERAH',
+            'KEPALA BIRO',
+            'ASISTEN',
+            'KEPALA SEKRETARIAT KOMISI PEMILU',
+            'SEKRETARIS DPRD',
+            'KEPALA INSPEKTORAT',
+            'INSPEKTUR DAERAH',
+            'SEKRETARIS INSPEKTORAT',
+            'KEPALA DINAS',
+            'SEKRETARIS DINAS',
+            'KEPALA BADAN',
+            'KEPALA PELAKSANA HARIAN BADAN',
+            'KEPALA SATUAN POLISI PAMONG PRAJA',
+        ),
+        '9' => array(
+            'KEPALA BALAI',
+            'KEPALA CABANG',
+            'KEPALA UPTD',
+            'KEPALA UNIT PELAKSANA TEKNIS DAERAH',
+            'DIREKTUR'
+        )
+    ]
+
+];


### PR DESCRIPTION
## Overview
- Add array constants named `peoplePositionGroups`
- This constants contains user positions groups classifications
- Each groups have different unread inbox behavior
- For groups 2 and 9 have the same counter method called `unreadCounterDeptQuery`

__
title: Add unread inbox counter for positions group 2 and 9
project: SIKD
participants: @samudra-ajri @indraprasetya154