### PR TITLE
Modify inbox receiver correction primary key

### DIFF
--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -18,10 +18,6 @@ class InboxReceiverCorrection extends Model
 
     public $timestamps = false;
 
-    protected $keyType = 'string';
-
-    protected $primaryKey = 'NId';
-
     public function draftDetail()
     {
         return $this->belongsTo(Draft::class, 'NId', 'NId_Temp');


### PR DESCRIPTION
## Overview
Modify the `InboxReceiverCorrection` table primary key from `NId` to `Id`.
This modification regarding to the `InboxReceiverCorrection` table structure changes.

__
title: Modify inbox receiver correction primary key
project: SIKD
participants: @samudra-ajri @indraprasetya154