### PR TITLE
Adjust draft timeline response with to_draft_* & forward status

### DIFF
--- a/src/app/GraphQL/Queries/DraftQuery.php
+++ b/src/app/GraphQL/Queries/DraftQuery.php
@@ -51,11 +51,19 @@ class DraftQuery
         $draftId = Arr::get($args, 'filter.draftId');
         $type = Arr::get($args, 'filter.type');
 
-        $inboxReceiverCorrections = InboxReceiverCorrection::where('NId', $draftId)
-                                                            ->where('ReceiverAs', $type)
+        $firstDraft = InboxReceiverCorrection::where('NId', $draftId)
+                                            ->where('ReceiverAs', 'LIKE', '%to_draft_%')
+                                            ->pluck('id');
+
+        $reviewDraft = InboxReceiverCorrection::where('NId', $draftId)
+                                            ->where('ReceiverAs', $type)
+                                            ->get()
+                                            ->unique('To_Id')
+                                            ->pluck('id');
+
+        $inboxReceiverCorrections = InboxReceiverCorrection::whereIn('id', $reviewDraft->merge($firstDraft))
                                                             ->orderBy('ReceiveDate', 'desc')
-                                                            ->get()
-                                                            ->unique('To_Id');
+                                                            ->get();
 
         return $inboxReceiverCorrections;
     }

--- a/src/app/GraphQL/Queries/DraftQuery.php
+++ b/src/app/GraphQL/Queries/DraftQuery.php
@@ -51,19 +51,14 @@ class DraftQuery
         $draftId = Arr::get($args, 'filter.draftId');
         $type = Arr::get($args, 'filter.type');
 
-        $firstDraft = InboxReceiverCorrection::where('NId', $draftId)
-                                            ->where('ReceiverAs', 'LIKE', '%to_draft_%')
-                                            ->pluck('id');
-
-        $reviewDraft = InboxReceiverCorrection::where('NId', $draftId)
-                                            ->where('ReceiverAs', $type)
-                                            ->get()
-                                            ->unique('To_Id')
-                                            ->pluck('id');
-
-        $inboxReceiverCorrections = InboxReceiverCorrection::whereIn('id', $reviewDraft->merge($firstDraft))
+        $inboxReceiverCorrection = new InboxReceiverCorrection();
+        $receiverAsReviewData = $inboxReceiverCorrection->getReceiverAsReviewData();
+        $receiverAsReviewData = Arr::prepend($receiverAsReviewData, $type);
+        $inboxReceiverCorrections = InboxReceiverCorrection::where('NId', $draftId)
+                                                            ->whereIn('ReceiverAs', $receiverAsReviewData)
                                                             ->orderBy('ReceiveDate', 'desc')
-                                                            ->get();
+                                                            ->get()
+                                                            ->unique('To_Id');
 
         return $inboxReceiverCorrections;
     }

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -180,14 +180,14 @@ class InboxReceiverCorrection extends Model
                 CustomReceiverTypeEnum::NUMBERING()->value     => ['Meminta Nomber Surat'],
                 CustomReceiverTypeEnum::SIGN_REQUEST()->value,
                 CustomReceiverTypeEnum::SIGNED()->value        => ['meneruskan'],
-                default => $this->getReceiverAsReviewData($receiverAs)
+                default => $this->getReceiverAsReviewData()
             };
             $receiverAs = array_merge($receiverAs, $receiverType);
         }
         return $receiverAs;
     }
 
-    protected function getReceiverAsReviewData($receiverAs)
+    public function getReceiverAsReviewData()
     {
         return [
             'to_draft_keluar',

--- a/src/graphql/inboxReceiverCorrection.graphql
+++ b/src/graphql/inboxReceiverCorrection.graphql
@@ -16,7 +16,7 @@ type InboxReceiverCorrection {
 }
 
 enum TimelineType {
-    CORRECTION @enum(value: "koreksi")
+    CORRECTION @enum(value: "meneruskan")
 }
 
 input DraftTimelineInput {


### PR DESCRIPTION
## Overview

- User should be able to see the timeline draft document before the signed document

## Changes
- Change query on `DraftQuery.php` add `whereIn` first draft (`to_draft_*`) and forward (`meneruskan`)

## Evidence
title: Menyesuaikan query draft timeline pada konsep nasak\ah dokumen sebelum ditandatangani
project: SIKD
participants: @indraprasetya154 @samudra-ajri