### PR TITLE
Add isFollowUp on inbox history

### DIFF
--- a/src/app/GraphQL/Mutations/InboxMutator.php
+++ b/src/app/GraphQL/Mutations/InboxMutator.php
@@ -78,7 +78,7 @@ class InboxMutator
         InboxReceiver::where('NId', $inboxId)
             ->where('To_Id', strval($peopleId))
             ->firstOrFail()
-            ->update(['Status' => 1]);
+            ->update(['Status' => 1, 'TindakLanjut' => 1]);
 
         return 'status updated';
     }

--- a/src/app/Models/InboxReceiver.php
+++ b/src/app/Models/InboxReceiver.php
@@ -32,7 +32,8 @@ class InboxReceiver extends Model
         'StatusReceive',
         'ReceiveDate',
         'To_Id_Desc',
-        'Status'
+        'Status',
+        'TindakLanjut'
     ];
 
     public function inboxDetail()

--- a/src/graphql/inboxReceiver.graphql
+++ b/src/graphql/inboxReceiver.graphql
@@ -11,6 +11,7 @@ type InboxReceiver {
     receiveStatus: String @rename(attribute: "StatusReceive")
     toIdMessage: String @rename(attribute: "To_Id_Message")
     isForwarded: Int @rename(attribute: "Status")
+    isFollowUp: Int @rename(attribute: "TindakLanjut")
     message: String @rename(attribute: "Msg")
     inboxDetail: Inbox @belongsTo
     sender: People @belongsTo

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -126,21 +126,27 @@ type Mutation {
 
     inboxForward(input: ForwardInput!): [InboxReceiver]
         @field(resolver: "InboxMutator@forward")
+        @guard
 
     endInboxForward(inboxId: String!): String
         @field(resolver: "InboxMutator@endForward")
+        @guard
 
     documentSignature(input: DocumentSignatureInput): DocumentSignatureSent
         @field(resolver: "DocumentSignatureMutator@signature")
+        @guard
 
     draftSignature(input: DraftSignatureInput): Draft
         @field(resolver: "DraftSignatureMutator@signature")
+        @guard
 
     documentSignatureReject(input: DocumentSignaturRejectInput): DocumentSignatureSent
         @field(resolver: "DocumentSignatureRejectMutator@reject")
+        @guard
 
     documentSignatureForward(input: DocumentSignatureForwardInput): [DocumentSignatureForward!]
         @field(resolver: "DocumentSignatureForwardMutator@forward")
+        @guard
 }
 
 #import auth.graphql


### PR DESCRIPTION
## Overview

- User should be able to see the status `isFollowUp` when the inbox is already actioned

## Changes
- Adjust inbox mutator for fill `TindakLanjut` field
- Add `isFollowUp` for flagging data is already actioned

## Implementation
````
{
  inboxHistory(
    inboxId: "218051121112809",
    first: 10
  ) {
    edges {
      node {
        id
        inboxId
        fromId
        toId
        isForwarded
        isFollowUp
        isEndForward
      }
    }
  }
}
````

## Evidence
title: User dapat melihat flag surat telah ditindaklanjuti pada history naskah
project: SIKD
participants: @indraprasetya154 @samudra-ajri