### PR TITLE
Add returning back draft to the drafter feature

### DIFF
--- a/src/app/GraphQL/Mutations/InboxReceiverCorrectionMutator.php
+++ b/src/app/GraphQL/Mutations/InboxReceiverCorrectionMutator.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace App\GraphQL\Mutations;
+
+use App\Models\InboxCorrection;
+use App\Models\InboxReceiverCorrection;
+use App\Models\People;
+use App\Models\TableSetting;
+use Illuminate\Support\Arr;
+use Carbon\Carbon;
+
+class InboxReceiverCorrectionMutator
+{
+    /**
+     * @param $rootValue
+     * @param $args
+     *
+     * @throws \Exception
+     *
+     * @return array
+     */
+    public function backToDrafter($rootValue, array $args)
+    {
+        $time = Carbon::now();
+        $inbox = InboxReceiverCorrection::findOrFail(Arr::get($args, 'input.id'));
+        $this->updateInboxStatus($inbox);
+        $this->createNewInboxCorrection($inbox, $args, $time);
+        $newInbox = $this->createNewInbox($inbox, $args, $time);
+        return $newInbox;
+    }
+
+    /**
+     * updateInboxStatus
+     * @param InboxReceiverCorrection $inbox
+     *
+     * @throws \Exception
+     *
+     * @return Void
+     */
+    protected function updateInboxStatus($inbox)
+    {
+        $inbox->Status = 1;
+        $inbox->save();
+    }
+
+    /**
+     * Create new inbox receiver correction record
+     * @param InboxReceiverCorrection $origin
+     * @param $args
+     * @param Object $time
+     *
+     * @throws \Exception
+     *
+     * @return InboxReceiverCorrection
+     */
+    protected function createNewInbox($origin, $args, $time)
+    {
+        $inbox                  = new InboxReceiverCorrection();
+        $inbox->NId             = $origin->NId;
+        $inbox->NKey            = TableSetting::first()->tb_key;
+        $inbox->GIR_Id          = auth()->user()->PeopleId . $time;
+        $inbox->From_Id         = auth()->user()->PeopleId;
+        $inbox->RoleId_From     = auth()->user()->PrimaryRoleId;
+        $inbox->To_Id           = $origin->From_Id;
+        $inbox->RoleId_To       = $origin->RoleId_From;
+        $inbox->ReceiverAs      = 'koreksi';
+        $inbox->Msg             = Arr::get($args, 'input.message');
+        $inbox->StatusReceive   = 'unread';
+        $inbox->ReceiveDate     = $time;
+        $inbox->To_Id_Desc      = People::findOrFail($origin->From_Id)->role->RoleName;
+        $inbox->save();
+
+        return $inbox;
+    }
+
+    /**
+     * Create inbox correction record
+     * @param InboxReceiverCorrection $origin
+     * @param $args
+     * @param Object $time
+     *
+     * @throws \Exception
+     *
+     * @return Void
+     */
+    protected function createNewInboxCorrection($origin, $args, $time)
+    {
+        $inbox          = new InboxCorrection();
+        $inbox->NId     = $origin->NId;
+        $inbox->GIR_Id  = auth()->user()->PeopleId . $time;
+        $inbox->Koreksi = Arr::get($args, 'input.options');
+        $inbox->RoleId  = auth()->user()->PrimaryRoleId;
+        $inbox->save();
+    }
+}

--- a/src/app/GraphQL/Mutations/InboxReceiverCorrectionMutator.php
+++ b/src/app/GraphQL/Mutations/InboxReceiverCorrectionMutator.php
@@ -23,8 +23,8 @@ class InboxReceiverCorrectionMutator
     {
         $time = Carbon::now();
         $inbox = InboxReceiverCorrection::findOrFail(Arr::get($args, 'input.id'));
-        $this->updateInboxStatus($inbox);
         $this->createNewInboxCorrection($inbox, $args, $time);
+        $this->updateInboxStatus($inbox);
         $newInbox = $this->createNewInbox($inbox, $args, $time);
         return $newInbox;
     }

--- a/src/app/Models/InboxCorrection.php
+++ b/src/app/Models/InboxCorrection.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class InboxCorrection extends Model
+{
+    use HasFactory;
+
+    protected $connection = 'sikdweb';
+
+    protected $table = 'inbox_koreksi';
+
+    public $timestamps = false;
+
+    protected $keyType = 'string';
+
+    protected $primaryKey = 'NId';
+
+    public function setGirIdAttribute($value)
+    {
+        $peopleId = substr($value, 0, -19);
+        $dateString = substr($value, -19);
+        $date = parseDateTimeFormat($dateString, 'dmyhis');
+
+        $this->attributes['GIR_Id'] = $peopleId . $date;
+    }
+
+    public function setKoreksiAttribute($value)
+    {
+        $correctionOptions = str_replace(', ', '|', $value);
+
+        $this->attributes['Koreksi'] = $correctionOptions;
+    }
+}

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -38,6 +38,22 @@ class InboxReceiverCorrection extends Model
         return $this->hasMany(PersonalAccessToken::class, 'tokenable_id', 'To_Id');
     }
 
+    public function setReceiveDateAttribute($value)
+    {
+        $this->attributes['ReceiveDate'] = $value->copy()->addHours(7);
+    }
+
+    public function setGirIdAttribute($value)
+    {
+        // GirId = peopleId + now (date in 'dmyhis' format)
+        // 19 means the datetime characters numbers
+        $peopleId = substr($value, 0, -19);
+        $dateString = substr($value, -19);
+        $date = parseDateTimeFormat($dateString, 'dmyhis');
+
+        $this->attributes['GIR_Id'] = $peopleId . $date;
+    }
+
     public function search($query, $search)
     {
         $query->whereIn('NId', function ($inboxQuery) use ($search) {

--- a/src/app/Models/MasterCorrectionOption.php
+++ b/src/app/Models/MasterCorrectionOption.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MasterCorrectionOption extends Model
+{
+    use HasFactory;
+
+    protected $connection = 'sikdweb';
+
+    protected $table = 'master_koreksi';
+
+    public $timestamps = false;
+
+    protected $keyType = 'string';
+
+    protected $primaryKey = 'KoreksiId';
+}

--- a/src/graphql/inboxReceiverCorrection.graphql
+++ b/src/graphql/inboxReceiverCorrection.graphql
@@ -1,4 +1,5 @@
 type InboxReceiverCorrection {
+    id: ID!
     draftId: String! @rename(attribute: "NId")
     groupId: String! @rename(attribute: "GIR_Id")
     date: DateTime! @rename(attribute: "ReceiveDate")
@@ -29,6 +30,13 @@ input DraftFilterInput {
     urgencies: String
     statuses: String
     receiverTypes: String
+}
+
+input DraftReturnInput {
+    id: ID!
+    options: String
+    drafterId: Int!
+    message: String
 }
 
 enum DraftObjectiveType {

--- a/src/graphql/masterCorrectionOption.graphql
+++ b/src/graphql/masterCorrectionOption.graphql
@@ -1,0 +1,4 @@
+type MasterCorrectionOption {
+    id: ID! @rename(attribute: "KoreksiId")
+    name: String @rename(attribute: "KoreksiName")
+}

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -118,6 +118,10 @@ type Query {
     ): [InboxReceiverCorrection!]!
         @field(resolver: "DraftQuery@timeline")
         @guard
+
+    correctionOptions: [MasterCorrectionOption!]!
+        @paginate(type: CONNECTION)
+        @guard
 }
 
 type Mutation {
@@ -158,3 +162,4 @@ type Mutation {
 #import documentSignatureForward.graphql
 #import masterDisposition.graphql
 #import inboxReceiverCorrection.graphql
+#import masterCorrectionOption.graphql

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -151,6 +151,10 @@ type Mutation {
     documentSignatureForward(input: DocumentSignatureForwardInput): [DocumentSignatureForward!]
         @field(resolver: "DocumentSignatureForwardMutator@forward")
         @guard
+
+    draftReturn(input: DraftReturnInput): InboxReceiverCorrection!
+        @field(resolver: "InboxReceiverCorrectionMutator@backToDrafter")
+        @guard
 }
 
 #import auth.graphql


### PR DESCRIPTION
## Overview
- Add `masterCorrectionOptions` query to show the data from `master_koreksi` table
- Add `draftReturn` mutation to rerturn the draft to the drafter

## Implementation
- `masterCorrectionOptions` query
```
{
  correctionOptions(first:10){
    edges{
      node{
        id
        name
      }
    }
  }
}
```
- `draftReturn` mutation
```
mutation{
  draftReturn(input: {
    id: 3432
    options: "XxJyPn38Yh.1, XxJyPn38Yh.10, XxJyPn38Yh.2"
    drafterId: 218
    message: "tolong diperbaiki"
  }){
    id
    draftId
    groupId
    date
    fromId
    toId
    message
    draftDetail{
      receiverAs
    }
  }
}
```

__
title: Add returning back draft to the drafter feature
project: SIKD
participants: @samudra-ajri @indraprasetya154