### PR TITLE
Add people id on document signature sent read

### DIFF
--- a/src/app/GraphQL/Queries/DocumentSignatureQuery.php
+++ b/src/app/GraphQL/Queries/DocumentSignatureQuery.php
@@ -89,6 +89,7 @@ class DocumentSignatureQuery
         if (!$documentSignatureSent->documentSignatureSentRead) {
             $data = new DocumentSignatureSentRead();
             $data->document_signature_sent_id = $documentSignatureSent->id;
+            $data->people_id = auth()->user()->PeopleId;
             $data->read = true;
             $data->save();
         }

--- a/src/app/Models/DocumentSignatureSent.php
+++ b/src/app/Models/DocumentSignatureSent.php
@@ -92,6 +92,7 @@ class DocumentSignatureSent extends Model
         if ($read || $unread) {
             $readId = DB::connection('mysql')->table('document_signature_sent_reads')
             ->select('document_signature_sent_id')
+            ->where('people_id', auth()->user()->PeopleId)
             ->pluck('document_signature_sent_id');
         }
 

--- a/src/database/migrations/2021_12_17_024429_add_column_people_id_document_signature_sent_reads_table.php
+++ b/src/database/migrations/2021_12_17_024429_add_column_people_id_document_signature_sent_reads_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddColumnPeopleIdDocumentSignatureSentReadsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('document_signature_sent_reads', function (Blueprint $table) {
+            $table->unsignedBigInteger('people_id')->after('document_signature_sent_id');
+
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('document_signature_sent_reads', function (Blueprint $table) {
+            $table->dropColumn('people_id');
+        });
+    }
+}


### PR DESCRIPTION
## Overview

- User should be able to see the flag read/unread document signature sent

## Changes
- Add people id on `document_signature_sent_reads` for flagging by user

## Evidence
title: Menambahkan field people id pada flagging document signature sent read
project: SIKD
participants: @indraprasetya154 @samudra-ajri