### PR TITLE
Add first data on inbox receiver correction for draft timeline

### DIFF
--- a/src/app/GraphQL/Queries/DraftQuery.php
+++ b/src/app/GraphQL/Queries/DraftQuery.php
@@ -56,10 +56,7 @@ class DraftQuery
 
         $inboxReceiverCorrection = new InboxReceiverCorrection();
         $receiverAsReviewData = $inboxReceiverCorrection->getReceiverAsReviewData();
-        //remove to_draft_keluar from list
-        if (($key = array_search('to_draft_keluar', $receiverAsReviewData)) !== false) {
-            unset($receiverAsReviewData[$key]);
-        }
+
         $draft = Draft::where('NId_temp', $draftId)->first();
         $hasNumber = $draft->nosurat ? true : false;
         $removeLatestId = false;


### PR DESCRIPTION
## Overview
- Add first data on inbox receiver correction for draft timeline

## Evidence
title: Add first data on inbox receiver correction for draft timeline
project: SIKD
participants: @indraprasetya154 @samudra-ajri