### PR TITLE
Modify filter by forward status condition

### DIFF
--- a/src/app/Http/Traits/InboxFilterTrait.php
+++ b/src/app/Http/Traits/InboxFilterTrait.php
@@ -80,7 +80,7 @@ trait InboxFilterTrait
     private function filterByForwardStatus($query, $filter)
     {
         $forwarded = $filter["forwarded"] ?? null;
-        if ($forwarded || $forwarded == 0) {
+        if ($forwarded || $forwarded != null) {
             $arrayForwarded = explode(", ", $forwarded);
             $query->whereIn('Status', $arrayForwarded);
         }


### PR DESCRIPTION
## Overview
- Modify the filter condition to catch the `null` status 

## Evidence
title: Modify filter by forward status condition
project: SIKD
participants: @samudra-ajri @indraprasetya154