### PR TITLE
Fix attachment if data was an array on a pdf report

### DIFF
--- a/src/resources/views/pdf/layouts/attachment/attachment_array.blade.php
+++ b/src/resources/views/pdf/layouts/attachment/attachment_array.blade.php
@@ -1,0 +1,29 @@
+@php
+    $data = json_decode($draft->lampiran);
+    $index = 0;
+    $length = count($data);
+@endphp
+@foreach ($data as $lampiran)
+    <div style="page-break-after: {{ ($index != $length - 1) ? "always" : "never" }};">
+        <div class="header-attachment">
+            <table style="text-align: justify">
+                <tbody>
+                    <tr>
+                        <td style="width: 70px; vertical-align: top;"><span class="attachment-list-number">LAMPIRAN </span></td>
+                        @include('pdf.layouts.attachment.header')
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+        <div class="clearfix"></div>
+        <div class="content-attachment">
+            <p style="line-height: 15px; text-align: justify;">
+                {!! $lampiran !!}<br>
+            </p>
+        </div>
+        @include('pdf.layouts.signature')
+    </div>
+    @php
+        $index++;
+    @endphp
+@endforeach

--- a/src/resources/views/pdf/layouts/master.blade.php
+++ b/src/resources/views/pdf/layouts/master.blade.php
@@ -107,6 +107,14 @@
                 margin: 0;
                 line-height: 16px
             }
+
+            .attachment-list-number {
+                counter-increment: item-counter;
+            }
+
+            .attachment-list-number:after {
+                content: counter(item-counter, upper-roman) ""; /* by specifying the upper-roman as style the output would be in roman numbers */
+            }
         </style>
     </head>
     <body>

--- a/src/resources/views/pdf/nota_dinas.blade.php
+++ b/src/resources/views/pdf/nota_dinas.blade.php
@@ -6,7 +6,7 @@
             font-size: 13px;
         }
     </style>
-    @if (($draft->lampiran != null && count(array_filter(json_decode($draft->lampiran))) > 0) || $draft->lampiran2 != null || $draft->lampiran3 != null || $draft->lampiran4 != null)
+    @if ($draft->lampiran != null && count(array_filter(json_decode($draft->lampiran))) > 0)
         @php $firstPageBreak = 'always'; @endphp
     @else
         @php $firstPageBreak = 'never'; @endphp
@@ -111,6 +111,6 @@
         </div>
     </div>
     @if ($draft->lampiran != null && count(array_filter(json_decode($draft->lampiran))) > 0)
-        @include('pdf.layouts.attachment.attachment')
+        @include('pdf.layouts.attachment.attachment_array')
     @endif
 @endsection


### PR DESCRIPTION
## Overview
- Fix attachment if data was an array on a pdf report

## Evidence
title: Fix attachment if data was an array on a pdf report
project: SIKD
participants: @indraprasetya154 @samudra-ajri