### PR TITLE
Create query draft history

### DIFF
--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -204,4 +204,9 @@ class InboxReceiverCorrection extends Model
             'to_draft_rekomendasi'
         ];
     }
+
+    public function history($query, $draftId)
+    {
+        return $query->where('NId', $draftId);
+    }
 }

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -119,6 +119,13 @@ type Query {
         @field(resolver: "DraftQuery@timeline")
         @guard
 
+    draftHistory(
+        draftId: String @builder(method: "App\\Models\\InboxReceiverCorrection@history")
+    ): [InboxReceiverCorrection!]!
+        @all
+        @orderBy(column: "ReceiveDate", direction: DESC)
+        @guard
+
     correctionOptions: [MasterCorrectionOption!]!
         @paginate(type: CONNECTION)
         @guard


### PR DESCRIPTION
## Overview
- Create query draft history

## Implementation
````
query {
  draftHistory(
    draftId: $draftId
  ) {
    id
    draftId
    groupId
    date
    fromId
    toId
    message
    receiverAs
    receiveStatus
    sender {
      id
      name
    }
    receiver {
      id
      name
    }
    isActioned
    draftDetail {
      letterNumber
    }
    senderRequestSignature {
      id
      name
    }
    ...
  }
}
````

## Evidence
title: Create query draft history
project: SIKD
participants: @indraprasetya154 @samudra-ajri