### PR TITLE
Add optional condition when draft detail letter number is null

### DIFF
--- a/src/app/GraphQL/Types/InboxReceiverCorrectionType.php
+++ b/src/app/GraphQL/Types/InboxReceiverCorrectionType.php
@@ -58,7 +58,7 @@ class InboxReceiverCorrectionType
 
     public function senderSignatureRequest($rootValue, array $args, GraphQLContext $context)
     {
-        $letterNumberDraft = $rootValue->draftDetail->nosurat;
+        $letterNumberDraft = optional($rootValue->draftDetail)->nosurat;
         if (!$letterNumberDraft) {
             return null;
         }


### PR DESCRIPTION
## Enhance from stakeholder
- Add optional condition when draft detail letter number is null

## Evidence
title: Add optional condition when draft detail letter number is null
project: SIKD
participants: @indraprasetya154 @samudra-ajri @ayocodingit @rizkyrmsyah @sandisunandar99 @rindibudiaramdhan 