### PR TITLE
Add lighthouse:cache on github workflow

### DIFF
--- a/.github/workflows/release-staging.yml
+++ b/.github/workflows/release-staging.yml
@@ -52,4 +52,4 @@ jobs:
         script: |
           docker service update --with-registry-auth --image ${{ secrets.DOCKER_IMAGENAME }}:${{ steps.vars.outputs.sha_short }} ${{ secrets.DOCKER_SERVICE_NAME_STAGING}}
           docker service ls --filter name=${{ secrets.DOCKER_SERVICE_NAME_STAGING}} --format "{{.Image}}"
-          docker exec $(docker container ls  | grep ${{ secrets.DOCKER_SERVICE_NAME_STAGING}}| awk '{print $1}') php artisan migrate
+          docker exec $(docker container ls  | grep ${{ secrets.DOCKER_SERVICE_NAME_STAGING}}| awk '{print $1}') php artisan migrate ; php artisan lighthouse:cache


### PR DESCRIPTION
## Overview
- Add `lighthouse:cache` on GitHub workflow for deployment purpose

## Reference
- https://lighthouse-php.com/master/performance/schema-caching.html

## Evidence
title: Add `lighthouse:cache` on GitHub workflow for deployment purpose
project: SIKD
participants: @indraprasetya154 @samudra-ajri @yohang88 