### PR TITLE
Modify the numbering temp condition

### DIFF
--- a/src/app/GraphQL/Mutations/InboxMutator.php
+++ b/src/app/GraphQL/Mutations/InboxMutator.php
@@ -63,7 +63,7 @@ class InboxMutator
 
         // TEMPORARY: NUMBERING_UK/TU will not get the notification
         if (
-            $action != PeopleProposedTypeEnum::NUMBERING_UK() ||
+            $action != PeopleProposedTypeEnum::NUMBERING_UK() &&
             $action != PeopleProposedTypeEnum::NUMBERING_TU()
         ) {
             $this->actionNotification($inboxData, $action);


### PR DESCRIPTION
## Overview
Modify the `or` into `and` condition for ignoring notification for numbering action. 

## Evidence
title: Modify the numbering temp condition
project: SIKD
participants: @samudra-ajri @indraprasetya154