### PR TITLE
Hide activity correction by the drafter on draft history

### DIFF
--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -238,6 +238,7 @@ class InboxReceiverCorrection extends Model
 
     public function history($query, $draftId)
     {
-        return $query->where('NId', $draftId);
+        return $query->where('ReceiverAs', '!=', 'to_koreksi')
+            ->where('NId', $draftId);
     }
 }


### PR DESCRIPTION
## Overview
Hide activity correction by the drafter on draft history

## Evidence
title: Hide activity correction by the drafter on draft history
project: SIKD
participants: @indraprasetya154 @samudra-ajri 