### PR TITLE
Fix read status on document signature sent history

### DIFF
--- a/src/app/Models/DocumentSignatureSent.php
+++ b/src/app/Models/DocumentSignatureSent.php
@@ -12,6 +12,8 @@ class DocumentSignatureSent extends Model
 {
     use HasFactory;
 
+    use \Awobaz\Compoships\Compoships;
+
     protected $connection = 'sikdweb';
 
     protected $table = 'm_ttd_kirim';
@@ -52,9 +54,7 @@ class DocumentSignatureSent extends Model
 
     public function documentSignatureSentRead()
     {
-        return $this->belongsTo(DocumentSignatureSentRead::class, 'id', 'document_signature_sent_id')->where(function ($query) {
-            $query->where('people_id', auth()->user()->PeopleId);
-        });
+        return $this->belongsTo(DocumentSignatureSentRead::class, ['id', 'PeopleIDTujuan'], ['document_signature_sent_id', 'people_id']);
     }
 
     public function documentSignature()

--- a/src/app/Models/DocumentSignatureSentRead.php
+++ b/src/app/Models/DocumentSignatureSentRead.php
@@ -9,5 +9,7 @@ class DocumentSignatureSentRead extends Model
 {
     use HasFactory;
 
+    use \Awobaz\Compoships\Compoships;
+
     protected $connection = 'mysql';
 }

--- a/src/composer.json
+++ b/src/composer.json
@@ -6,6 +6,7 @@
     "license": "MIT",
     "require": {
         "php": "^7.3|^8.0",
+        "awobaz/compoships": "^2.1",
         "barryvdh/laravel-dompdf": "^0.9.0",
         "doctrine/dbal": "^3.3",
         "endroid/qr-code": "^4.4",

--- a/src/composer.lock
+++ b/src/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a20761174115a471457b78099e8f3813",
+    "content-hash": "b9ebf0c6b9a736f1f59e52f42af0ed59",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -61,6 +61,66 @@
                 "source": "https://github.com/asm89/stack-cors/tree/v2.0.3"
             },
             "time": "2021-03-11T06:42:03+00:00"
+        },
+        {
+            "name": "awobaz/compoships",
+            "version": "2.1.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/topclaudy/compoships.git",
+                "reference": "c5b107f16a2a8650fb2dbc21babd4a65a0f48585"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/topclaudy/compoships/zipball/c5b107f16a2a8650fb2dbc21babd4a65a0f48585",
+                "reference": "c5b107f16a2a8650fb2dbc21babd4a65a0f48585",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/database": ">=5.6 <10.0"
+            },
+            "require-dev": {
+                "ext-sqlite3": "*"
+            },
+            "suggest": {
+                "awobaz/blade-active": "Blade directives for the Laravel 'Active' package",
+                "awobaz/eloquent-auto-append": "Automatically append accessors to model serialization",
+                "awobaz/eloquent-mutators": "Reusable mutators (getters/setters) for Laravel 5's Eloquent",
+                "awobaz/syntactic": "Syntactic sugar for named and indexed parameters call."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Awobaz\\Compoships\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Claudin J. Daniel",
+                    "email": "cdaniel@awobaz.com"
+                }
+            ],
+            "description": "Laravel relationships with support for composite/multiple keys",
+            "keywords": [
+                "laravel",
+                "laravel composite keys",
+                "laravel relationships"
+            ],
+            "support": {
+                "issues": "https://github.com/topclaudy/compoships/issues",
+                "source": "https://github.com/topclaudy/compoships/tree/2.1.3"
+            },
+            "funding": [
+                {
+                    "url": "https://paypal.me/awobaz",
+                    "type": "custom"
+                }
+            ],
+            "time": "2021-11-29T22:11:22+00:00"
         },
         {
             "name": "bacon/bacon-qr-code",


### PR DESCRIPTION
## Overview
Fix read status on document signature sent history

## Issue
Eloquent doesn't support composite keys. As a consequence, there is no way to define a relationship from one model to another by matching more than one column. Trying to use where clauses (like in the example below) won't work when eager loading the relationship because at the time the relationship is processed $this->team_id is null.

## Problem Solving
Use this package: https://github.com/topclaudy/compoships

## Evidence
title: Fix read status on document signature sent history
project: SIKD
participants: @indraprasetya154 @samudra-ajri 