### PR TITLE
Enhance documentSignatureForward receiver document

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureForwardMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureForwardMutator.php
@@ -3,11 +3,13 @@
 namespace App\GraphQL\Mutations;
 
 use App\Enums\DocumentSignatureSentNotificationTypeEnum;
+use App\Enums\PeopleGroupTypeEnum;
 use App\Enums\SignatureStatusTypeEnum;
 use App\Http\Traits\SendNotificationTrait;
 use App\Exceptions\CustomException;
 use App\Models\DocumentSignatureForward;
 use App\Models\DocumentSignatureSent;
+use App\Models\People;
 use Carbon\Carbon;
 use Illuminate\Support\Arr;
 
@@ -25,10 +27,11 @@ class DocumentSignatureForwardMutator
      */
     public function forward($rootValue, array $args)
     {
-        $documentSignatureId = Arr::get($args, 'input.documentSignatureId');
-        $sender = Arr::get($args, 'input.sender');
+        $documentSignatureSentId = Arr::get($args, 'input.documentSignatureSentId');
+        $documentSignatureSent = DocumentSignatureSent::where('id', $documentSignatureSentId)
+                                    ->first();
 
-        $documentSignatureForwardIds = $this->doForward($documentSignatureId, $sender, $args);
+        $documentSignatureForwardIds = $this->doForward($documentSignatureSent, $args);
 
         if (!$documentSignatureForwardIds) {
             throw new CustomException(
@@ -37,11 +40,7 @@ class DocumentSignatureForwardMutator
             );
         }
 
-        $data = DocumentSignatureSent::where('ttd_id', $documentSignatureId)
-                                    ->where('PeopleIDTujuan', $sender)
-                                    ->first();
-
-        $this->doSendNotification($data->id, $data->receiver->PeopleName);
+        $this->doSendNotification($documentSignatureSent->id, $documentSignatureSent->receiver->PeopleName);
 
         return $documentSignatureForwardIds;
     }
@@ -72,33 +71,68 @@ class DocumentSignatureForwardMutator
     /**
      * doForward
      *
-     * @param  string $documentSignatureId
+     * @param  object $documentSignatureSentId
      * @param  string $sender
      * @param  mixed $args
      * @return array
      */
-    public function doForward($documentSignatureId, $sender, $args)
+    public function doForward($documentSignatureSent, $args)
     {
-        $receivers = Arr::get($args, 'input.receivers');
-        $arrayReceivers = explode(", ", $receivers);
         $note = Arr::get($args, 'input.note');
         $ids = array();
+        $receiver = $this->forwardReceiver($documentSignatureSent);
 
-        foreach ($arrayReceivers as $key => $receiver) {
-            $key++;
-            $documentSignatureForward = DocumentSignatureForward::create([
-                'ttd_id' => $documentSignatureId,
-                'catatan' => $note,
-                'tgl' => Carbon::now(),
-                'PeopleID' => $sender,
-                'PeopleIDTujuan' => $receiver,
-                'urutan' => $key,
-                'status' => SignatureStatusTypeEnum::WAITING()->value,
-            ]);
+        if ($receiver != null) {
+            foreach ($receiver as $key => $receiver) {
+                $key++;
+                $documentSignatureForward = DocumentSignatureForward::create([
+                    'ttd_id' => $documentSignatureSent->ttd_id,
+                    'catatan' => $note,
+                    'tgl' => Carbon::now(),
+                    'PeopleID' => $documentSignatureSent->PeopleIDTujuan,
+                    'PeopleIDTujuan' => $receiver,
+                    'urutan' => $key,
+                    'status' => SignatureStatusTypeEnum::WAITING()->value,
+                ]);
 
-            array_push($ids, $documentSignatureForward);
+                array_push($ids, $documentSignatureForward);
+            }
+
+            return $ids;
         }
 
-        return $ids;
+        return false;
+    }
+
+    /**
+     * forwardReceiver
+     *
+     * @param  mixed $type
+     * @return mixed
+     */
+    public function forwardReceiver($documentSignatureSent)
+    {
+        $type = optional($documentSignatureSent->documentSignature->documentSignatureType)->document_forward_target;
+        switch ($type) {
+            case 'UK':
+                $receiver = People::whereHas('role', function ($role) {
+                    $role->where('RoleCode', auth()->user()->role->RoleCode);
+                    $role->where('GRoleId', auth()->user()->role->GRoleId);
+                })->where('GroupId', PeopleGroupTypeEnum::UK()->value)->pluck('PeopleId');
+                break;
+
+            case 'TU':
+                $receiver = People::whereHas('role', function ($role) {
+                    $role->where('RoleCode', auth()->user()->role->RoleCode);
+                    $role->where('Code_Tu', auth()->user()->role->Code_Tu);
+                })->where('GroupId', PeopleGroupTypeEnum::TU()->value)->pluck('PeopleId');
+                break;
+
+            default:
+                $receiver = null;
+                break;
+        }
+
+        return $receiver;
     }
 }

--- a/src/app/GraphQL/Mutations/DocumentSignatureForwardMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureForwardMutator.php
@@ -115,17 +115,21 @@ class DocumentSignatureForwardMutator
         $type = optional($documentSignatureSent->documentSignature->documentSignatureType)->document_forward_target;
         switch ($type) {
             case 'UK':
-                $receiver = People::whereHas('role', function ($role) {
-                    $role->where('RoleCode', auth()->user()->role->RoleCode);
-                    $role->where('GRoleId', auth()->user()->role->GRoleId);
-                })->where('GroupId', PeopleGroupTypeEnum::UK()->value)->pluck('PeopleId');
-                break;
-
             case 'TU':
-                $receiver = People::whereHas('role', function ($role) {
+                if ($type == 'UK') {
+                    $peopleGroupType = PeopleGroupTypeEnum::UK()->value;
+                    $whereField = 'GRoleId';
+                    $whereParams = auth()->user()->role->GRoleId;
+                }
+                if ($type == 'TU') {
+                    $peopleGroupType = PeopleGroupTypeEnum::TU()->value;
+                    $whereField = 'Code_Tu';
+                    $whereParams = auth()->user()->role->Code_Tu;
+                }
+                $receiver = People::whereHas('role', function ($role) use ($whereField, $whereParams) {
                     $role->where('RoleCode', auth()->user()->role->RoleCode);
-                    $role->where('Code_Tu', auth()->user()->role->Code_Tu);
-                })->where('GroupId', PeopleGroupTypeEnum::TU()->value)->pluck('PeopleId');
+                    $role->where($whereField, $whereParams);
+                })->where('GroupId', $peopleGroupType)->pluck('PeopleId');
                 break;
 
             default:

--- a/src/app/Models/DocumentSignature.php
+++ b/src/app/Models/DocumentSignature.php
@@ -38,4 +38,9 @@ class DocumentSignature extends Model
     {
         return $this->belongsTo(InboxFile::class, 'file', 'FileName_real');
     }
+
+    public function documentSignatureType()
+    {
+        return $this->belongsTo(DocumentSignatureType::class, 'type_id', 'id');
+    }
 }

--- a/src/app/Models/DocumentSignatureType.php
+++ b/src/app/Models/DocumentSignatureType.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DocumentSignatureType extends Model
+{
+    use HasFactory;
+
+    protected $connection = 'sikdweb';
+
+    protected $table = 'm_ttd_types';
+
+    public $timestamps = false;
+}

--- a/src/graphql/documentSignature.graphql
+++ b/src/graphql/documentSignature.graphql
@@ -18,9 +18,7 @@ input DocumentSignaturRejectInput {
 }
 
 input DocumentSignatureForwardInput {
-    documentSignatureId: String!
-    sender: String!
-    receivers: String!
+    documentSignatureSentId: String!
     note: String
 }
 


### PR DESCRIPTION
## Overview
- Now we don't need to choose UK/TU first on a mobile screen, because we have document type for sending the document to UK/TU
- Enhance documentSignatureForward receiver document

## ToDo
Frontend (mobile) need change paramters from:
````
docuumentSignatureId
sender
receiver
note
````
to:
````
documentSignatureSentId
note
````

## Related Task
https://app.clickup.com/t/2nc67v5

## Evidence
Enhance documentSignatureForward receiver document
project: SIKD
participants: @indraprasetya154 @samudra-ajri 