### PR TITLE
Add outbox signature searching and filtering

### DIFF
--- a/src/app/Models/DocumentSignatureSent.php
+++ b/src/app/Models/DocumentSignatureSent.php
@@ -107,14 +107,9 @@ class DocumentSignatureSent extends Model
             $documentSignatureSentIds = array_diff($documentSignatureSentIds, $readId);
         }
 
-
         $query->whereIn('id', $documentSignatureSentIds);
 
-        if ($statuses  || $statuses == '0') {
-            $arrayStatuses = explode(", ", $statuses);
-            $query->whereIn('status', $arrayStatuses);
-        }
-
+        $this->filterByStatus($query, $filter);
         return $query;
     }
 
@@ -161,5 +156,20 @@ class DocumentSignatureSent extends Model
     public function getUrutanParentAttribute()
     {
         return $this->urutan - 1;
+    }
+
+    public function outboxFilter($query, $filter)
+    {
+        $this->filterByStatus($query, $filter);
+        return $query;
+    }
+
+    private function filterByStatus($query, $filter)
+    {
+        $statuses = $filter['statuses'] ?? null;
+        if ($statuses || $statuses == '0') {
+            $arrayStatuses = explode(", ", $statuses);
+            $query->whereIn('status', $arrayStatuses);
+        }
     }
 }

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -30,6 +30,10 @@ input documentSignatureSentsInput {
     withReceiver: Boolean
 }
 
+input outboxDocumentSignatureSentsInput {
+    statuses: String
+}
+
 input documentSignatureSentTimelineInput {
     documentSignatureId: String!
     sort: String!

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -74,6 +74,7 @@ type Query {
 
     outboxDocumentSignatureSents(
         search: String @builder(method: "App\\Models\\DocumentSignatureSent@search")
+        filter: outboxDocumentSignatureSentsInput @builder(method: "App\\Models\\DocumentSignatureSent@outboxFilter")
     ): [DocumentSignatureSent!]!
         @whereAuth(relation: "sender")
         @orderBy(column: "tgl", direction: DESC)

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -72,7 +72,9 @@ type Query {
         @paginate(type: CONNECTION)
         @guard
 
-    outboxDocumentSignatureSents: [DocumentSignatureSent!]!
+    outboxDocumentSignatureSents(
+        search: String @builder(method: "App\\Models\\DocumentSignatureSent@search")
+    ): [DocumentSignatureSent!]!
         @whereAuth(relation: "sender")
         @orderBy(column: "tgl", direction: DESC)
         @paginate(type: CONNECTION)


### PR DESCRIPTION
## Overview
- Add outbox signature sent searching feature 
- Add filtering by statuses

## ToDo
The client (mobile) should query this feature by:
````
outboxDocumentSignatureSents(
    first: 20
    search: "...."
    filter: {
        statuses: "0, 1, 4" 
    }
) {
    edges {
        node {
            ....
        }
    }
}
````

## Evidence
title: Add outbox signature searching and filtering
project: SIKD
participants: @samudra-ajri @indraprasetya154  