### PR TITLE
Add outbox signature objectives

### DIFF
--- a/src/app/Enums/ObjectiveTypeEnum.php
+++ b/src/app/Enums/ObjectiveTypeEnum.php
@@ -10,7 +10,6 @@ use Spatie\Enum\Enum;
  * @method static self REVISE()
  */
 
-final class DraftObjectiveTypeEnum extends Enum
+final class ObjectiveTypeEnum extends Enum
 {
-
 }

--- a/src/app/Models/DocumentSignatureSent.php
+++ b/src/app/Models/DocumentSignatureSent.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\ObjectiveTypeEnum;
 use App\Enums\SignatureStatusTypeEnum;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -55,6 +56,29 @@ class DocumentSignatureSent extends Model
     public function documentSignature()
     {
         return $this->belongsTo(DocumentSignature::class, 'ttd_id', 'id');
+    }
+
+    public function objective($query, $objective)
+    {
+        $userId = auth()->user()->PeopleId;
+        switch ($objective) {
+            case ObjectiveTypeEnum::IN():
+                $query->where(fn($query) => $query
+                    ->where('PeopleIDTujuan', $userId)
+                    ->orWhere('PeopleID', $userId)
+                    ->where('status', '!=', SignatureStatusTypeEnum::WAITING()->value)
+                );
+                break;
+
+            case ObjectiveTypeEnum::OUT():
+                $query->where(fn($query) => $query
+                    ->where('PeopleID', $userId)
+                    ->orWhere('PeopleIDTujuan', $userId)
+                    ->where('status', '!=', SignatureStatusTypeEnum::WAITING()->value)
+                );
+                break;
+        }
+        return $query;
     }
 
     public function filter($query, $filter)

--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -3,7 +3,7 @@
 namespace App\Models;
 
 use App\Enums\CustomReceiverTypeEnum;
-use App\Enums\DraftObjectiveTypeEnum;
+use App\Enums\ObjectiveTypeEnum;
 use App\Enums\ListTypeEnum;
 use App\Http\Traits\InboxFilterTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -108,17 +108,17 @@ class InboxReceiverCorrection extends Model
         });
 
         switch ($objective) {
-            case DraftObjectiveTypeEnum::IN():
+            case ObjectiveTypeEnum::IN():
                 $query->where('From_Id', '!=', $userId)
                     ->where('ReceiverAs', '!=', 'to_koreksi');
                 break;
 
-            case DraftObjectiveTypeEnum::OUT():
+            case ObjectiveTypeEnum::OUT():
                 $query->where(fn($query) => $query->whereNull('To_Id')
                         ->orWhere('To_Id', '!=', $userId));
                 break;
 
-            case DraftObjectiveTypeEnum::REVISE():
+            case ObjectiveTypeEnum::REVISE():
                 $query->where('From_Id', $userId)
                     ->where('To_Id', $userId);
                 break;

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -54,6 +54,11 @@ enum StatusType {
     UNSIGNED
 }
 
+enum ObjectiveType {
+    IN
+    OUT
+}
+
 #import people.graphql
 #import documentSignature.graphql
 #import documentSignatureForward.graphql

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -75,8 +75,8 @@ type Query {
     outboxDocumentSignatureSents(
         search: String @builder(method: "App\\Models\\DocumentSignatureSent@search")
         filter: outboxDocumentSignatureSentsInput @builder(method: "App\\Models\\DocumentSignatureSent@outboxFilter")
+        objective: ObjectiveType @builder(method: "App\\Models\\DocumentSignatureSent@objective")
     ): [DocumentSignatureSent!]!
-        @whereAuth(relation: "sender")
         @orderBy(column: "tgl", direction: DESC)
         @paginate(type: CONNECTION)
         @guard


### PR DESCRIPTION
## Overview
- These objectives can be valued by `IN` or `OUT`
- `objective=IN` will filter the inbox signatures list that user received
- `objective=OUT` will filter the inbox signatures list that user sent

## Evidence
title: Add outbox signature objectives
project: SIKD
participants: @samudra-ajri @indraprasetya154 