### PR TITLE
Add made from draft attribute on type inbox detail schema graphql

### DIFF
--- a/src/app/Models/DocumentSignatureForward.php
+++ b/src/app/Models/DocumentSignatureForward.php
@@ -4,7 +4,7 @@ namespace App\Models;
 
 use App\Enums\SignatureStatusTypeEnum;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Hoyvoy\CrossDatabase\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 
 class DocumentSignatureForward extends Model

--- a/src/app/Models/Inbox.php
+++ b/src/app/Models/Inbox.php
@@ -34,6 +34,16 @@ class Inbox extends Model
         return $this->belongsTo(InboxFile::class, 'NId', 'NId');
     }
 
+    public function draft()
+    {
+        return $this->belongsTo(Draft::class, 'NId', 'NId_Temp');
+    }
+
+    public function getMadeFromDraftAttribute(): bool
+    {
+        return (bool) $this->draft()->exists();
+    }
+
     public function getDocumentBaseUrlAttribute()
     {
         return config('sikd.base_path_file');

--- a/src/app/Models/InboxReceiver.php
+++ b/src/app/Models/InboxReceiver.php
@@ -6,7 +6,7 @@ use App\Enums\ListTypeEnum;
 use App\Enums\PeopleGroupTypeEnum;
 use App\Http\Traits\InboxFilterTrait;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
-use Hoyvoy\CrossDatabase\Eloquent\Model;
+use Illuminate\Database\Eloquent\Model;
 
 class InboxReceiver extends Model
 {

--- a/src/graphql/inbox.graphql
+++ b/src/graphql/inbox.graphql
@@ -9,6 +9,7 @@ type Inbox {
     fromOrg: String @rename(attribute: "Instansipengirim")
     about: String @rename(attribute: "Hal")
     type: DocumentType @belongsTo
+    madeFromDraft: Boolean @rename(attribute: "made_from_draft")
     urgency: DocumentUrgency @belongsTo
     createdBy: People @belongsTo
     documentBaseUrl: String @rename(attribute: "document_base_url")


### PR DESCRIPTION
## Overview
- Add made from the draft attribute on type inbox detail schema graphql
- Attribute `madeFromDraft` has boolean type

## Update InboxDetail Schema
### Example
````
inboxDetail {
          id
          date
          fromName
          letterNumber
          about
          type {
            name
          }
          urgency {
            name
          }
          **madeFromDraft**
          documentBaseUrl
          documentPath
          documentFile {
            name
          }
          createdBy {
            name
            avatar {
              url
            }
          }
        }
      }
````

## Evidence
title: Add made from the draft attribute on type inbox detail schema graphql
project: SIKD
participants: @indraprasetya154 @samudra-ajri