### PR TITLE
Modify regional inbox unread counter

### DIFF
--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -9,7 +9,6 @@ use App\Exceptions\CustomException;
 use App\Models\DocumentSignatureSent;
 use App\Models\InboxReceiver;
 use App\Models\InboxReceiverCorrection;
-use Illuminate\Support\Facades\DB;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
 class InboxQuery
@@ -119,7 +118,6 @@ class InboxQuery
     private function unreadCountDeptQuery($context)
     {
         $user = $context->user;
-        $deptCode = $user->role->RoleCode;
         $query = InboxReceiver::where('RoleId_To', $user->PrimaryRoleId)
             ->where('StatusReceive', 'unread')
             ->whereIn('ReceiverAs', ['to_forward', 'bcc'])

--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -122,12 +122,7 @@ class InboxQuery
         $deptCode = $user->role->RoleCode;
         $query = InboxReceiver::where('RoleId_To', $user->PrimaryRoleId)
             ->where('StatusReceive', 'unread')
-            ->where('ReceiverAs', 'to_forward')
-            ->whereHas('sender', function ($senderQuery) use ($deptCode) {
-                $senderQuery->whereHas('role', function ($roleQuery) use ($deptCode) {
-                    $roleQuery->where('RoleCode', '=', $deptCode);
-                });
-            })
+            ->whereIn('ReceiverAs', ['to_forward', 'bcc'])
             ->whereHas('inboxDetail', function ($detailQuery) {
                 $detailQuery->where('Pengirim', '=', 'eksternal');
             });


### PR DESCRIPTION
## Overview
- This modification regards to the new inbox list receiverAs attribute addtioned
- It was `receiverAs=bcc`

## Evidence
title: Modify regional inbox unread counter
project: SIKD
participants: @samudra-ajri @indraprasetya154