### PR TITLE
Modify the outbox drafts filter

### DIFF
--- a/src/app/Models/InboxReceiverCorrection.php
+++ b/src/app/Models/InboxReceiverCorrection.php
@@ -153,7 +153,8 @@ class InboxReceiverCorrection extends Model
                 array_push($arrayReceiverTypes, 'meneruskan');
                 $arrayReceiverTypes = array_merge($this->getReceiverAsReviewData(), $arrayReceiverTypes);
             }
-            $query->whereIn('ReceiverAs', $arrayReceiverTypes);
+            $query->whereIn('ReceiverAs', $arrayReceiverTypes)
+                ->whereNotNull('action_label');
         }
     }
 


### PR DESCRIPTION
## Overview
- This modification according to the new implementation of `action_label`
- The filter only returns the records that already implemented this label
- It means the record where the `action_label` is not null

## Evidence
title: Modify the outbox drafts filter
project: SIKD
participants: @samudra-ajri @indraprasetya154
