### PR TITLE
Add regional disposition inbox receiver scope

### DIFF
--- a/src/app/Enums/InboxReceiverScopeType.php
+++ b/src/app/Enums/InboxReceiverScopeType.php
@@ -7,7 +7,8 @@ use Spatie\Enum\Enum;
 /**
  * @method static self REGIONAL()
  * @method static self INTERNAL()
- * @method static self DISPOSITION()
+ * @method static self INTERNAL_DISPOSITION()
+ * @method static self REGIONAL_DISPOSITION()
  */
 
 final class InboxReceiverScopeType extends Enum

--- a/src/app/GraphQL/Queries/InboxQuery.php
+++ b/src/app/GraphQL/Queries/InboxQuery.php
@@ -61,8 +61,9 @@ class InboxQuery
         }
 
         $internalCount = $this->unreadCountQuery(InboxReceiverScopeType::INTERNAL(), $context);
-        $dispositionCount = $this->unreadCountQuery(InboxReceiverScopeType::DISPOSITION(), $context);
-        $regionalCount = (int) $forwardCount + (int) $dispositionCount;
+        $dispositionCount = $this->unreadCountQuery(InboxReceiverScopeType::INTERNAL_DISPOSITION(), $context);
+        $regionalDispositionCount = $this->unreadCountQuery(InboxReceiverScopeType::REGIONAL_DISPOSITION(), $context);
+        $regionalCount = (int) $forwardCount + (int) $regionalDispositionCount;
         $signatureCount = $this->unreadCountSignatureQuery($context);
         $draftCount = $this->draftUnreadCountQuery($context);
 
@@ -103,7 +104,10 @@ class InboxQuery
             $query->where('To_Id', $user->PeopleId);
         }
 
-        if ($scope == InboxReceiverScopeType::DISPOSITION()) {
+        if (
+            $scope == InboxReceiverScopeType::INTERNAL_DISPOSITION() ||
+            $scope == InboxReceiverScopeType::REGIONAL_DISPOSITION()
+        ) {
             $query->where('ReceiverAs', 'cc1');
         } elseif ($scope == InboxReceiverScopeType::REGIONAL()) {
             $query->whereHas('inboxDetail', fn($query) => $query->where('Pengirim', 'eksternal'));
@@ -198,10 +202,11 @@ class InboxQuery
     {
         switch ($scope) {
             case InboxReceiverScopeType::REGIONAL():
+            case InboxReceiverScopeType::REGIONAL_DISPOSITION():
                 return '!=';
 
             case InboxReceiverScopeType::INTERNAL():
-            case InboxReceiverScopeType::DISPOSITION():
+            case InboxReceiverScopeType::INTERNAL_DISPOSITION():
                 return '=';
         }
     }


### PR DESCRIPTION
## Overview
- Add `REGIONAL_DISPOSITION` enum
- Modify `DISPOSITION` enum into `INTERNAL_DISPOSITION`
- Modify the unread regional count value as the accumulation of forward and regional disposition count

## Evidence
title: Add regional disposition inbox receiver scope
project: SIKD
participants: @samudra-ajri @indraprasetya154
