### PR TITLE
Fix title split on next page letter recommendation pdf template

### DIFF
--- a/src/resources/views/pdf/surat_rekomendasi.blade.php
+++ b/src/resources/views/pdf/surat_rekomendasi.blade.php
@@ -60,7 +60,9 @@
             <div class="row has-margin-bottom">
                 <div class="column" style="width: 110px">Dasar</div>
                 <div class="column" style="width: 13px">:</div>
-                <div class="column align-justify list-no-margin" style="width: 480px;">{!! $draft->Hal !!}</div>
+            </div>
+            <div class="align-justify list-no-margin" style="position: relative; left: 123px; top: -30px; width: 480px;">
+                {!! $draft->Hal !!}
             </div>
             @php $content = json_decode($draft->Konten); @endphp
             <div class="row has-margin-bottom">


### PR DESCRIPTION
## Overview
- Fix title split on next page letter recommendation pdf template

## Related Task
- https://app.clickup.com/t/2g50rhx

## Evidence
title: Fix title split on next page letter recommendation pdf template
project: SIKD
participants: @indraprasetya154 @samudra-ajri