### PR TITLE
Add distribution draft filter

### DIFF
--- a/src/app/Enums/CustomReceiverTypeEnum.php
+++ b/src/app/Enums/CustomReceiverTypeEnum.php
@@ -10,6 +10,7 @@ use Spatie\Enum\Enum;
  * @method static self SIGN_REQUEST()
  * @method static self SIGNED()
  * @method static self REVIEW()
+ * @method static self DISTRIBUTION()
  */
 
 final class CustomReceiverTypeEnum extends Enum


### PR DESCRIPTION
## Overview
- Add DISTRIBUTION custom receiver type enum
- This filter will return the letters which has `SURAT DINAS` type and the receiver is `Unit Kearsipan`

## ToDo
- The filter cannot using multiple values
- The client (mobile) should use this query:
```
{
  outboxDrafts(
    filter: {
      receiverTypes: "distribution"
    }
  )
}
```

## Evidence
title: Add distribution draft filter
project: SIKD
participants: @samudra-ajri @indraprasetya154
