### PR TITLE
Add inbox external drafts list

### DIFF
--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -133,6 +133,12 @@ type Query {
     ): InboxReceiverCorrection
         @field(resolver: "DraftQuery@detail")
         @guard
+    
+    externalDrafts: [DocumentSignatureForward!]!
+        @whereAuth(relation: "receiver")
+        @orderBy(column: "tgl", direction: DESC)
+        @paginate(type: CONNECTION)
+        @guard
 
     draftTimeline(
         filter: DraftTimelineInput @builder(method: "App\\Models\\InboxReceiverCorrection@timeline")


### PR DESCRIPTION
## Overview
- Add the inbox of external drafts list
- External draft is a letter that drafted outside sikd

## ToDo
- The client (mobile) should use this query:
```
{
  externalDrafts(first: 50){
    ....
  }
}
 ```

## Evidence
title: Add inbox external drafts list
project: SIKD
participants: @samudra-ajri @indraprasetya154
