### PR TITLE
Add isRead attribute on Signature Forward schema

### DIFF
--- a/src/graphql/documentSignatureForward.graphql
+++ b/src/graphql/documentSignatureForward.graphql
@@ -8,6 +8,7 @@ type DocumentSignatureForward {
     note: String @rename(attribute: "catatan")
     status: String
     sort: String @rename(attribute: "urutan")
+    isRead: Int @rename(attribute: "is_read")
     next: String
     sender: People!
     receiver: People!


### PR DESCRIPTION
## Overview
Add `isRead` attribute on `DoucmentSignatureForward` gql schema.

## Evidence
title: Add isRead attribute on Signature Forward schema
project: SIKD
participants: @samudra-ajri @indraprasetya154

