### PR TITLE
Modify the read status after signature response

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -182,7 +182,8 @@ class DocumentSignatureMutator
         $updateDocumentSent = tap(DocumentSignatureSent::where('id', $data->id))->update([
             'status' => SignatureStatusTypeEnum::SUCCESS()->value,
             'next' => 1,
-            'tgl_ttd' => setDateTimeNowValue()
+            'tgl_ttd' => setDateTimeNowValue(),
+            'is_sender_read' => false
         ])->first();
 
         //check if any next siganture require

--- a/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
@@ -4,6 +4,7 @@ namespace App\GraphQL\Mutations;
 
 use App\Enums\DocumentSignatureSentNotificationTypeEnum;
 use App\Enums\SignatureStatusTypeEnum;
+use App\Enums\StatusReadTypeEnum;
 use App\Http\Traits\SendNotificationTrait;
 use App\Exceptions\CustomException;
 use App\Models\DocumentSignatureSent;
@@ -29,7 +30,8 @@ class DocumentSignatureRejectMutator
         $documentSignatureSent = tap(DocumentSignatureSent::where('id', $documentSignatureSentId))->update([
             'status' => SignatureStatusTypeEnum::REJECT()->value,
             'catatan' => $note,
-            'tgl' => setDateTimeNowValue()
+            'tgl' => setDateTimeNowValue(),
+            'is_sender_read' => false
         ])->first();
 
         if (!$documentSignatureSent) {


### PR DESCRIPTION
## Overview 
- When a document is rejected the read status on the sender is false
- Similar thing when the document is signatured

## Evidence
title: Modify the read status after signature response
project: SIKD
participants: @samudra-ajri @indraprasetya154