### PR TITLE
Add status read resolver

### DIFF
--- a/src/app/GraphQL/Types/DocumentSignatureSentType.php
+++ b/src/app/GraphQL/Types/DocumentSignatureSentType.php
@@ -51,6 +51,8 @@ class DocumentSignatureSentType
     }
 
      /**
+     * The read status used for the history
+     *
      * @param $rootValue
      * @param array                                                    $args
      * @param \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null $context
@@ -60,6 +62,26 @@ class DocumentSignatureSentType
     public function isRead($rootValue, array $args, GraphQLContext $context)
     {
         if ($rootValue->is_receiver_read == true || $rootValue->is_sender_read == true) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+     /**
+     * The read status used for the list
+     *
+     * @param $rootValue
+     * @param array                                                    $args
+     * @param \Nuwave\Lighthouse\Support\Contracts\GraphQLContext|null $context
+     *
+     * @return Boolean
+     */
+    public function statusRead($rootValue, array $args, GraphQLContext $context)
+    {
+        if ($rootValue->PeopleIDTujuan == auth()->user()->PeopleId && $rootValue->is_receiver_read == true) {
+            return true;
+        } elseif ($rootValue->PeopleID == auth()->user()->PeopleId && $rootValue->is_sender_read == true) {
             return true;
         } else {
             return false;

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -12,6 +12,7 @@ type DocumentSignatureSent {
     sender: People!
     receiver: People!
     read: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isRead")
+    statusRead: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@statusRead")
     isLastSigned: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isLastSigned")
     parent: DocumentSignatureSent @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@parent")
     documentSignature: DocumentSignature @belongsTo


### PR DESCRIPTION
## Overview
The `statusRead` is used for the read/unread label on the signature list, different from the history list that used `isRead` label.

## ToDo
The client (mobile) should change the attribute from `isRead` into `statusRead` in the query.

## Evidence
title: Add status read resolver
project: SIKD
participants: @samudra-ajri @indraprasetya154