### PR TITLE
Add optional function to the draft detail object

### DIFF
--- a/src/app/Http/Traits/SendNotificationTrait.php
+++ b/src/app/Http/Traits/SendNotificationTrait.php
@@ -131,8 +131,8 @@ trait SendNotificationTrait
                 'draftId' => $record->NId,
                 'groupId' => $record->GIR_Id,
                 'receiverAs' => $record->ReceiverAs,
-                'letterNumber' => $record->draftDetail->nosurat,
-                'draftStatus' => $record->draftDetail->Konsep,
+                'letterNumber' => optional($record->draftDetail)->nosurat,
+                'draftStatus' => optional($record->draftDetail)->Konsep,
                 'action' => $action
             ];
         }


### PR DESCRIPTION
## Overview
This function will handle the records that have no draft detail object.

## Evidence
title: Add optional function to the draft detail object
project: SIKD
participants: @samudra-ajri @indraprasetya154