### PR TITLE
Add document signature distribute at document signature history

### DIFF
--- a/src/app/GraphQL/Mutations/DistributeDocumentMutator.php
+++ b/src/app/GraphQL/Mutations/DistributeDocumentMutator.php
@@ -2,9 +2,12 @@
 
 namespace App\GraphQL\Mutations;
 
+use App\Enums\ActionLabelTypeEnum;
+use App\Enums\SignatureStatusTypeEnum;
 use App\Exceptions\CustomException;
 use App\Http\Traits\DistributeToInboxReceiverTrait;
 use App\Models\DocumentSignature;
+use App\Models\DocumentSignatureForward;
 use App\Models\Inbox;
 use App\Models\InboxFile;
 use App\Models\TableSetting;
@@ -49,6 +52,10 @@ class DistributeDocumentMutator
             $this->createInboxReceiver($tableKey, $inboxId, $stringReceiversIds);
             $this->createInboxFile($tableKey, $inboxId, $documentSignature);
             $this->doSendNotification($inboxId, $args, $stringReceiversIds);
+
+            DocumentSignatureForward::where('ttd_id', $documentSignatureId)
+                                ->where('PeopleIDTujuan', auth()->user()->PeopleId)
+                                ->update(['status' => SignatureStatusTypeEnum::SUCCESS()->value]);
         }
 
         return $documentSignature;

--- a/src/app/GraphQL/Queries/DocumentSignatureHistoryQuery.php
+++ b/src/app/GraphQL/Queries/DocumentSignatureHistoryQuery.php
@@ -3,10 +3,9 @@
 namespace App\GraphQL\Queries;
 
 use App\Exceptions\CustomException;
-use App\Models\DocumentSignature;
 use App\Models\DocumentSignatureForward;
 use App\Models\DocumentSignatureSent;
-use App\Models\DocumentSignatureSentRead;
+use App\Models\InboxReceiver;
 use GraphQL\Type\Definition\ResolveInfo;
 use Nuwave\Lighthouse\Support\Contracts\GraphQLContext;
 
@@ -39,7 +38,17 @@ class DocumentSignatureHistoryQuery
                                     ->orderBy('urutan', 'ASC')
                                     ->get();
 
+        //select one document signature sent, get name file for relation to inbox file
+        $inboxId = optional($documentSignatureSent->first()->documentSignature->inboxFile)->NId;
+        $documentSignatureDistribute = null;
+        if ($inboxId) {
+            $documentSignatureDistribute = InboxReceiver::where('NId', $inboxId)
+                                        ->where('ReceiverAs', 'to')
+                                        ->get();
+        }
+
         $data = collect([
+            'documentSignatureDistribute' => $documentSignatureDistribute,
             'documentSignatureForward' => $documentSignatureForward,
             'documentSignatureSent' => $documentSignatureSent,
         ]);

--- a/src/app/GraphQL/Queries/DocumentSignatureHistoryQuery.php
+++ b/src/app/GraphQL/Queries/DocumentSignatureHistoryQuery.php
@@ -23,6 +23,7 @@ class DocumentSignatureHistoryQuery
     public function history($rootValue, array $args, GraphQLContext $context)
     {
         $documentSignatureSent = DocumentSignatureSent::where('ttd_id', $args['documentSignatureId'])
+                                    ->with(['sender', 'receiver'])
                                     ->orderBy('urutan', 'ASC')
                                     ->get();
 
@@ -35,6 +36,7 @@ class DocumentSignatureHistoryQuery
         }
 
         $documentSignatureForward = DocumentSignatureForward::where('ttd_id', $args['documentSignatureId'])
+                                    ->with(['sender', 'receiver'])
                                     ->orderBy('urutan', 'ASC')
                                     ->get();
 
@@ -43,6 +45,7 @@ class DocumentSignatureHistoryQuery
         $documentSignatureDistribute = null;
         if ($inboxId) {
             $documentSignatureDistribute = InboxReceiver::where('NId', $inboxId)
+                                        ->with(['sender', 'receiver'])
                                         ->where('ReceiverAs', 'to')
                                         ->get();
         }

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -23,6 +23,7 @@ type DocumentSignatureSentTimelines {
 }
 
 type DocumentSignatureSentHistory {
+    documentSignatureDistribute: [InboxReceiver]
     documentSignatureForward: [DocumentSignatureForward]
     documentSignatureSent: [DocumentSignatureSent]
 }
@@ -63,3 +64,4 @@ enum ObjectiveType {
 #import people.graphql
 #import documentSignature.graphql
 #import documentSignatureForward.graphql
+#import inboxReceiver.graphql


### PR DESCRIPTION
## Overview
- Add document signature distribute at document signature history
- Change **status** `documentSignatureForward` to `1` after **distributed**

## Related Task
- https://app.clickup.com/t/2jfbvq2

## Note
Since documnet **already distributed** and **recorded** on `inbox_receiver table`
Attribute `documentSignatureDistribute` has type `InboxReceiver` structrure

## Example Mutator
````
{ 
  documentSignatureSentHistory(documentSignatureId : "123456789") {
      documentSignatureDistribute{
        sender{
          name
          position
        }
        receiver{
          name
          position
        }
      }
      documentSignatureForward{
        date
        status
        note
        sender{
          name
          position
        }
        receiver{
          name
          position
        }
      }
      documentSignatureSent{
        date
        status
        note
        sender{
          name
          position
        }
        receiver{
          name
          position
        }
        read
        id
        sort
      }
    }
}
````

## Evidence
title: Add document signature distribute at document signature history
project: SIKD
participants: @indraprasetya154 @samudra-ajri