### PR TITLE
Revert "Add internal drafts list for UK/TU"

### DIFF
--- a/src/app/Models/Draft.php
+++ b/src/app/Models/Draft.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use App\Enums\PeopleGroupTypeEnum;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -153,54 +152,5 @@ class Draft extends Model
                 return 1;
                 break;
         }
-    }
-
-    /**
-     * Defining the archiver (TU or UK)
-     *
-     * @param Object $query
-     * @param Array $filter
-     *
-     * @return object
-     */
-    public function archiver($query, $isArchiver)
-    {
-        if ($isArchiver) {
-            switch (auth()->user()->GroupId) {
-                case PeopleGroupTypeEnum::TU()->value:
-                    $query->where(
-                        fn($query) => $query
-                            ->where('Approve_People', auth()->user()->PeopleId)
-                            ->orWhere('RoleId_from', auth()->user()->PrimaryRoleId)
-                    );
-                    break;
-
-                case PeopleGroupTypeEnum::UK()->value:
-                    $query->where(
-                        fn($query) => $query
-                            ->where('Approve_People', auth()->user()->PeopleId)
-                            ->orWhere('RoleId_from', auth()->user()->PrimaryRoleId)
-                            ->whereIn('Ket', $this->getUKFolderDesc())
-                    );
-            }
-        }
-        return $query;
-    }
-
-    protected function getUKFolderDesc()
-    {
-        return array(
-            'outbox',
-            'outboxkeluar',
-            'outboxsprint',
-            'outboxundangan',
-            'outboxsprint',
-            'outboxinstruksigub',
-            'outboxedaran',
-            'outboxsket',
-            'outboxsuratizin',
-            'outboxsprintgub',
-            'outboxsupertugas'
-        );
     }
 }

--- a/src/graphql/schema.graphql
+++ b/src/graphql/schema.graphql
@@ -147,13 +147,6 @@ type Query {
         @field(resolver: "ExternalDraftQuery@detail")
         @guard
 
-    internalDrafts(
-        isArchiver: Boolean @builder(method: "App\\Models\\Draft@archiver")
-    ): [Draft!]!
-        @orderBy(column: "TglNaskah", direction: DESC)
-        @paginate(type: CONNECTION)
-        @guard
-
     draftTimeline(
         filter: DraftTimelineInput @builder(method: "App\\Models\\InboxReceiverCorrection@timeline")
     ): [InboxReceiverCorrection!]!
@@ -220,6 +213,10 @@ type Mutation {
 
     draftNumber(input: DraftNumberInput): InboxReceiverCorrection!
         @field(resolver: "DraftNumberMutator@addNumber")
+        @guard
+
+    distributeInbox(input: DistributeInboxInput): Inbox!
+        @field(resolver: "DistributeInboxMutator@distributeInbox")
         @guard
 }
 


### PR DESCRIPTION
## Overview
- Reverts jabardigitalservice/office-services#331
- This function cannot accomated the distributed list
- This revert because this feature already accomodate by `Drafts` query

## ToDo
This feature can be accomodate by this query:
```
{
  drafts(
    objective: IN
    first: 20
    filter: {
      receiverTypes: "Meminta Nomber Surat, meneruskan"
    }
  ){
    ...
  }
}

```

## Evidence
title: Revert "Add internal drafts list for UK/TU"
project: SIKD
participants: @samudra-ajri @indraprasetya154