### PR TITLE
Remove rename file on first order if the document has a footer

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -172,12 +172,9 @@ class DocumentSignatureMutator
                 'has_footer' => true,
             ]);
         } else {
-            if ($data->urutan == 1) {
-                $updateFileData = DocumentSignature::where('id', $data->ttd_id)->update([
-                    'status' => SignatureStatusTypeEnum::SUCCESS()->value,
-                    'file' => $newFileName,
-                ]);
-            }
+            $updateFileData = DocumentSignature::where('id', $data->ttd_id)->update([
+                'status' => SignatureStatusTypeEnum::SUCCESS()->value,
+            ]);
         }
 
         //update status document sent to 1 (signed)


### PR DESCRIPTION
## Overview
- Remove rename file on first order if the document has a footer

## Evidence
title: Remove rename file on first order if the document has a footer
project: SIKD
participants: @indraprasetya154 @samudra-ajri 