### PR TITLE
Change response of inbox receiver attribute in draft history

### DIFF
--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -306,11 +306,12 @@ class DraftSignatureMutator
     {
         $receiver = $this->getTargetInboxReceiver($draft);
         $labelReceiverAs = ($draft->ket === 'outboxnotadinas') ? 'to_notadinas' : 'to_forward';
-        $this->doForwardToInboxReceiver($draft, $receiver, $labelReceiverAs);
+        $groupId = auth()->user()->PeopleId . Carbon::now();
+        $this->doForwardToInboxReceiver($draft, $receiver, $labelReceiverAs, $groupId);
 
         if ($draft->RoleId_Cc != null) {
             $peopleCCIds = People::whereIn('PrimaryRoleId', explode(',', $draft->RoleId_Cc))->get();
-            $this->doForwardToInboxReceiver($draft, $peopleCCIds, 'bcc');
+            $this->doForwardToInboxReceiver($draft, $peopleCCIds, 'bcc', $groupId);
         }
 
         return $receiver;
@@ -321,16 +322,17 @@ class DraftSignatureMutator
      *
      * @param  mixed $draft
      * @param  mixed $receiver
-     * @param  mixed $receiverAs
+     * @param  string $receiverAs
+     * @param  string $groupId
      * @return void
      */
-    protected function doForwardToInboxReceiver($draft, $receiver, $receiverAs)
+    protected function doForwardToInboxReceiver($draft, $receiver, $receiverAs, $groupId)
     {
         foreach ($receiver as $key => $value) {
             $InboxReceiver = new InboxReceiver();
             $InboxReceiver->NId           = $draft->NId_Temp;
             $InboxReceiver->NKey          = TableSetting::first()->tb_key;
-            $InboxReceiver->GIR_Id        = auth()->user()->PeopleId . Carbon::now();
+            $InboxReceiver->GIR_Id        = $groupId;
             $InboxReceiver->From_Id       = auth()->user()->PeopleId;
             $InboxReceiver->RoleId_From   = auth()->user()->PrimaryRoleId;
             $InboxReceiver->To_Id         = $value->PeopleId;

--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -309,7 +309,7 @@ class DraftSignatureMutator
         $groupId = auth()->user()->PeopleId . Carbon::now();
         $this->doForwardToInboxReceiver($draft, $receiver, $labelReceiverAs, $groupId);
 
-        if ($draft->RoleId_Cc != null) {
+        if ($draft->RoleId_Cc != null && $draft->Ket == 'outboxnotadinas') {
             $peopleCCIds = People::whereIn('PrimaryRoleId', explode(',', $draft->RoleId_Cc))->get();
             $this->doForwardToInboxReceiver($draft, $peopleCCIds, 'bcc', $groupId);
         }

--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -304,12 +304,13 @@ class DraftSignatureMutator
 
     protected function forwardToInboxReceiver($draft)
     {
-        $receiver = $this->getTargetInboxReceiver($draft);
-        $labelReceiverAs = ($draft->ket === 'outboxnotadinas') ? 'to_notadinas' : 'to_forward';
+        $draftReceiverAsToTarget = config('constants.draftReceiverAsToTarget');
+        $receiver = $this->getTargetInboxReceiver($draft, $draftReceiverAsToTarget);
+        $labelReceiverAs = (in_array($draft->ket, array_keys($draftReceiverAsToTarget))) ? $draftReceiverAsToTarget[$draft->Ket] : 'to_forward';
         $groupId = auth()->user()->PeopleId . Carbon::now();
         $this->doForwardToInboxReceiver($draft, $receiver, $labelReceiverAs, $groupId);
 
-        if ($draft->RoleId_Cc != null && $draft->Ket == 'outboxnotadinas') {
+        if ($draft->RoleId_Cc != null && in_array($draft->ket, array_keys($draftReceiverAsToTarget))) {
             $peopleCCIds = People::whereIn('PrimaryRoleId', explode(',', $draft->RoleId_Cc))->get();
             $this->doForwardToInboxReceiver($draft, $peopleCCIds, 'bcc', $groupId);
         }
@@ -353,12 +354,13 @@ class DraftSignatureMutator
      * getTargetInboxReceiver
      *
      * @param  mixed $draft
+     * @param  array $draftReceiverAsToTarget
      * @return array
      */
 
-    protected function getTargetInboxReceiver($draft)
+    protected function getTargetInboxReceiver($draft, $draftReceiverAsToTarget)
     {
-        if ($draft->Ket === 'outboxnotadinas') {
+        if (in_array($draft->ket, array_keys($draftReceiverAsToTarget))) {
             $peopleIds = People::whereIn('PeopleId', explode(',', $draft->RoleId_To))->get();
         } else {
             $peopleIds = People::whereHas('role', function ($role) {

--- a/src/app/GraphQL/Queries/DraftHistoryQuery.php
+++ b/src/app/GraphQL/Queries/DraftHistoryQuery.php
@@ -37,16 +37,23 @@ class DraftHistoryQuery
         }
 
         $inboxReceiver = null;
+        $draft = Draft::where('NId_Temp', $args['draftId'])->first();
         $inboxReceiver = InboxReceiver::with(['sender', 'receiver'])
-                                ->orWhere(function ($query) use ($args) {
-                                    $query->where('NId', $args['draftId'])
-                                        ->where('ReceiverAs', 'LIKE', '%to%')
-                                        ->where('ReceiverAs', 'NOT LIKE', 'to_draft%');
+                                ->orWhere(function ($query) use ($args, $draft) {
+                                    $query->where('NId', $args['draftId']);
+                                    $query->where('ReceiverAs', 'LIKE', '%to%');
+                                    $query->where('ReceiverAs', 'NOT LIKE', 'to_draft%');
+                                    if ($draft->Ket != 'outboxnotadinas') {
+                                        $query->where('ReceiverAs', '<>', 'to_forward');
+                                    }
                                 })
-                                ->orWhere(function ($query) use ($args) {
-                                    $query->where('NId', $args['draftId'])
-                                        ->where('ReceiverAs', 'bcc')
-                                        ->where('ReceiverAs', 'NOT LIKE', 'to_draft%');
+                                ->orWhere(function ($query) use ($args, $draft) {
+                                    $query->where('NId', $args['draftId']);
+                                    $query->where('ReceiverAs', 'bcc');
+                                    $query->where('ReceiverAs', 'NOT LIKE', 'to_draft%');
+                                    if ($draft->Ket != 'outboxnotadinas') {
+                                        $query->where('ReceiverAs', '<>', 'to_forward');
+                                    }
                                 })
                                 ->orderBy('id', 'DESC')
                                 ->get();

--- a/src/config/constants.php
+++ b/src/config/constants.php
@@ -51,4 +51,15 @@ return [
         'XxJyPn38Yh.40'
     ],
 
+    //receiver as on draft for direct sent to target (not forward to UK)
+    'draftReceiverAsToTarget' => [
+        'outboxnotadinas'       => 'to_notadinas',
+        'outboxsprint'          => 'to_sprint',
+        'outboxpengumuman'      => 'to_pengumuman',
+        'outboxsuratizin'       => 'to_surat_izin_keluar',
+        'outboxsprintgub'       => 'to_sprint_gub',
+        'outboxrekomendasi'     => 'to_rekomendasi',
+        'outboxsupertugas'      => 'to_super_tugas_keluar',
+    ],
+
 ];


### PR DESCRIPTION
## Overview
- Change response of inbox receiver attribute in draft history
- Change rule of forwarding draft after e-sign

## Evidence
title: Change response of inbox receiver attribute in draft history
project: SIKD
participants: @indraprasetya154 @samudra-ajri