### PR TITLE
Set const draftReceiverAsToTarget above forward inbox receiver

### DIFF
--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -177,8 +177,9 @@ class DraftSignatureMutator
         $this->doUpdateInboxReceiverCorrection($draft);
         //Forward the document to TU / UK
         $this->forwardToInbox($draft);
-        $this->forwardToInboxReceiver($draft);
-        if ($draft->Ket !== 'outboxnotadinas') {
+        $draftReceiverAsToTarget = config('constants.draftReceiverAsToTarget');
+        $this->forwardToInboxReceiver($draft, $draftReceiverAsToTarget);
+        if (in_array($draft->ket, array_keys($draftReceiverAsToTarget))) {
             $this->forwardSaveInboxReceiverCorrection($draft);
         }
         return $signature;
@@ -302,9 +303,8 @@ class DraftSignatureMutator
      * @return void
      */
 
-    protected function forwardToInboxReceiver($draft)
+    protected function forwardToInboxReceiver($draft, $draftReceiverAsToTarget)
     {
-        $draftReceiverAsToTarget = config('constants.draftReceiverAsToTarget');
         $receiver = $this->getTargetInboxReceiver($draft, $draftReceiverAsToTarget);
         $labelReceiverAs = (in_array($draft->ket, array_keys($draftReceiverAsToTarget))) ? $draftReceiverAsToTarget[$draft->Ket] : 'to_forward';
         $groupId = auth()->user()->PeopleId . Carbon::now();


### PR DESCRIPTION
## Overview
- Set const draftReceiverAsToTarget above forward inbox receiver

## Evidence
title: Set const draftReceiverAsToTarget above forward inbox receiver
project: SIKD
participants: @indraprasetya154 @samudra-ajri