### PR TITLE
Add exclude filter on inbox history

### DIFF
--- a/src/app/Models/InboxReceiver.php
+++ b/src/app/Models/InboxReceiver.php
@@ -49,7 +49,6 @@ class InboxReceiver extends Model
     {
         return $query->where('NId', $filter['inboxId'])
             ->where(function ($query) use ($filter) {
-                $status = $filter['status'] ?? null;
                 if ($filter['withAuthCheck']) {
                     $query->whereIn('GIR_Id', function ($query) {
                         $query->select('GIR_Id')
@@ -58,9 +57,17 @@ class InboxReceiver extends Model
                     })
                     ->orWhere('RoleId_From', 'like', auth()->user()->PrimaryRoleId . '%');
                 }
+            })
+            ->where(function ($query) use ($filter) {
+                $status = $filter['status'] ?? null;
+                $excludeStatus = $filter['excludeStatus'] ?? null;
                 if ($status) {
                     $status = explode(', ', $status);
                     $query->whereIn('ReceiverAs', $status);
+                }
+                if ($excludeStatus) {
+                    $excludeStatus = explode(', ', $excludeStatus);
+                    $query->whereNotIn('ReceiverAs', $excludeStatus);
                 }
             });
     }

--- a/src/graphql/inboxReceiver.graphql
+++ b/src/graphql/inboxReceiver.graphql
@@ -53,6 +53,7 @@ input InboxHistoryFilterInput {
     inboxId: String!
     withAuthCheck: Boolean!
     status: String
+    excludeStatus: String
 }
 
 input DistributeDocumentToInboxInput {


### PR DESCRIPTION
## Overview
- Add exclude filter on inbox history

## Todo
- Add `excludeStatus:  "bcc"` params on inboxHistory when user hit from detail inbox
````
inboxHistory(
        filter: {
          inboxId : "123123123123123123123" //sample inboxId
          withAuthCheck : true
          excludeStatus: "bcc"
        } 
        first: 10
      ){
        ...
        ...
        ...
      }
}
````

## Note
`excludeStatus` can be used with any `ReceiverAs` value

## Evidence
title: Add exclude filter on inbox history
project: SIKD
participants: @indraprasetya154 @samudra-ajri