### PR TITLE
Set documentSignatureSelf on document signature history

### DIFF
--- a/src/graphql/documentSignature.graphql
+++ b/src/graphql/documentSignature.graphql
@@ -1,6 +1,9 @@
 type DocumentSignature {
     id: String!
     name: String @rename(attribute: "nama_file")
+    createdBy: People! @belongsTo(relation: "people")
+    createdAt: String @rename(attribute: "tanggal")
+    updatedAt: String @rename(attribute: "tanggal_update")
     url: String
     code: String
     validation: Validation @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureType@validate")

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -26,6 +26,7 @@ type DocumentSignatureSentHistory {
     documentSignatureDistribute: [InboxReceiver]
     documentSignatureForward: [DocumentSignatureForward]
     documentSignatureSent: [DocumentSignatureSent]
+    documentSignatureSelf: DocumentSignature
 }
 
 input documentSignatureSentsInput {


### PR DESCRIPTION
## Overview
- Set documentSignatureSelf on document signature history

## Todo
- Use attribute `documentSignatureSelf` (check documentation first for see response)
````
{ 
    documentSignatureSentHistory(documentSignatureId : "1234567689"){ //sample
      documentSignatureDistribute{
        ....  
      }
      documentSignatureForward{
        ....
      }
      documentSignatureSent{
        ...
      }
      documentSignatureSelf {
        id
        createdBy {
          name
        }
        createdAt //use it when updatedAt is null
        updatedAt //use it when data not null
      }
    }
}
````

## Related PR on the website
- https://gitlab.com/jdsteam/sikd-website/-/merge_requests/189


## Evidence
title: Set documentSignatureSelf on document signature history
project: SIKD
participants: @indraprasetya154 @samudra-ajri