### PR TITLE
Add disposition proposed people list underictive ordering

### DIFF
--- a/src/app/Models/People.php
+++ b/src/app/Models/People.php
@@ -147,6 +147,8 @@ class People extends Authenticatable
         $positionGroup = $this->dispositionGroup4Query($query, $userPosition, $positions) ?? $positionGroup;
         $positionGroup = $this->dispositionGroup5Query($query, $userPosition, $positions) ?? $positionGroup;
         $this->dispositionGroupDefaultQuery($query, $positionGroup);
+        $query->orderBy('PrimaryRoleId', 'asc');
+        $query->orderBy('PeopleId', 'asc');
     }
 
     /**


### PR DESCRIPTION
## Overview
- This order query will overtake the lighthouse `orderBy` directive.
- This takeovering is needed reagards to the users have same roleId possibility.

## Evidence
title: Add disposition proposed people list underictive ordering
project: SIKD
participants: @samudra-ajri @indraprasetya154