### PR TITLE
Ignore TU Role from forwarding document notadinas group after esign

### DIFF
--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -326,6 +326,7 @@ class DraftSignatureMutator
         if ($draft->RoleId_Cc != null && in_array($draft->Ket, array_keys($draftReceiverAsToTarget))) {
             $peopleCCIds = People::whereIn('PrimaryRoleId', explode(',', $draft->RoleId_Cc))
                             ->where('PeopleIsActive', PeopleIsActiveEnum::ACTIVE()->value)
+                            ->where('GroupId', '!=', PeopleGroupTypeEnum::TU()->value)
                             ->get();
             $this->doForwardToInboxReceiver($draft, $peopleCCIds, 'bcc', $groupId);
         }


### PR DESCRIPTION
## Overview
- Ignore TU Role from forwarding document notadinas group after esign

## Evidence
title: Ignore TU Role from forwarding document notadinas group after esign
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214 