### PR TITLE
Add notification to target after draft esign

### DIFF
--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -350,6 +350,7 @@ class DraftSignatureMutator
     {
         $receiverIds = [];
         foreach ($receiver as $key => $value) {
+            // get people id for send the notification if draft direct send to target (NOT to_forward status = to UK)
             if ($receiverAs != 'to_forward') {
                 array_push($receiverIds, $value->PeopleId);
             }


### PR DESCRIPTION
## Overview
- Add notification to target after draft esign

## Related Task
- https://app.clickup.com/t/2a1q8fh

## Evidence
title: Add notification to target after draft esign
project: SIKD
participants: @indraprasetya154 @samudra-ajri