### PR TITLE
Add condition label to on inbox history when draft is non disposition

### DIFF
--- a/src/app/Enums/InboxTypeEnum.php
+++ b/src/app/Enums/InboxTypeEnum.php
@@ -7,6 +7,7 @@ use Spatie\Enum\Enum;
 /**
  * @method static self INBOX()
  * @method static self OUTBOX()
+ * @method static self OUTBOXNOTADINAS()
  */
 
 final class InboxTypeEnum extends Enum
@@ -16,6 +17,7 @@ final class InboxTypeEnum extends Enum
         return [
             'INBOX' => 'inbox',
             'OUTBOX' => 'outbox',
+            'OUTBOXNOTADINAS' => 'outboxnotadinas',
         ];
     }
 }

--- a/src/app/Models/InboxReceiver.php
+++ b/src/app/Models/InboxReceiver.php
@@ -163,8 +163,16 @@ class InboxReceiver extends Model
 
     public function getReceiverAsLabelAttribute()
     {
+        $nonDispositionLabel = '';
+        if (
+            $this->inboxDetail->NTipe == InboxTypeEnum::INBOX()->value ||
+            $this->inboxDetail->NTipe == InboxTypeEnum::OUTBOXNOTADINAS()->value
+        ) {
+            $nonDispositionLabel = ' Non Disposisi';
+        }
+
         $label = match ($this->ReceiverAs) {
-            'to'                    => ($this->inboxDetail->NTipe == InboxTypeEnum::INBOX()->value) ? 'Naskah Masuk Non Disposisi' : 'Naskah Masuk',
+            'to'                    => 'Naskah Masuk' . $nonDispositionLabel,
             'to_undangan'           => 'Undangan',
             'to_sprint'             => 'Perintah',
             'to_notadinas'          => 'Nota Dinas',


### PR DESCRIPTION
## Overview
- Add condition label 'to' on inbox history when the draft is non disposition

## Related Task
- https://app.clickup.com/t/25cwf58?comment=804690660

## Evidence
title: Add condition label 'to' on inbox history when the draft is non disposition
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214 