### PR TITLE
Re set group id on forward notification after esign

### DIFF
--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -448,6 +448,11 @@ class DraftSignatureMutator
         $people = auth()->user()->PeopleName;
         $draftType = $draft->draftType->JenisName;
         $draftTitle = $draft->Hal;
+        // set group id value
+        $peopleId = substr($groupId, 0, -19);
+        $dateString = substr($groupId, -19);
+        $date = parseDateTimeFormat($dateString, 'dmyhis');
+        $groupId = $peopleId . $date;
 
         $body = $people . ' telah mengrimkan ' . $draftType . ' terkait dengan ' . $draftTitle . '. Klik disini untuk membaca dan menindaklanjuti pesan.';
         $messageAttribute = [


### PR DESCRIPTION
## Overview
- Re set group id on forwarding document (notification) after esign

## Related Task
- https://app.clickup.com/t/2a1q8fh?comment=810877329

## Evidence
title: Re set group id on forwarding document (notification) after esign
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214 