### PR TITLE
Add previous attribute on document signature sent response

### DIFF
--- a/src/app/Models/DocumentSignatureSent.php
+++ b/src/app/Models/DocumentSignatureSent.php
@@ -43,6 +43,11 @@ class DocumentSignatureSent extends Model
         return $this->belongsTo(People::class, 'PeopleID', 'PeopleId');
     }
 
+    public function previous()
+    {
+        return $this->belongsTo(People::class, 'previous_sender_id', 'PeopleId');
+    }
+
     public function receiverPersonalAccessTokens()
     {
         return $this->hasMany(PersonalAccessToken::class, 'tokenable_id', 'PeopleIDTujuan');

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -11,6 +11,7 @@ type DocumentSignatureSent {
     next: String
     sender: People! @with(relation: "sender")
     receiver: People! @with(relation: "receiver")
+    previous: People! @with(relation: "previous")
     read: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isRead")
     statusRead: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@statusRead")
     isLastSigned: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isLastSigned")


### PR DESCRIPTION
## Overview
- Add previous attribute on document signature sent response

## Related Task
- https://app.clickup.com/t/2d8fy18

## ToDo
- Use previous attribute to get people name

## Evidence
title: Add previous attribute on document signature sent response
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214 