### PR TITLE
Add attachment attribute on document signature response

### DIFF
--- a/src/app/Models/DocumentSignature.php
+++ b/src/app/Models/DocumentSignature.php
@@ -30,6 +30,16 @@ class DocumentSignature extends Model
         return $file;
     }
 
+    public function getAttachmentAttribute()
+    {
+        if ($this->lampiran != null) {
+            $path = config('sikd.base_path_file');
+            return $path . 'ttd/lampiran/' . $this->lampiran;
+        }
+
+        return null;
+    }
+
     public function people()
     {
         return $this->belongsTo(People::class, 'PeopleID', 'PeopleId');

--- a/src/graphql/documentSignature.graphql
+++ b/src/graphql/documentSignature.graphql
@@ -6,6 +6,8 @@ type DocumentSignature {
     updatedAt: String @rename(attribute: "tanggal_update")
     url: String
     code: String
+    attachment: String
+    note: String @rename(attribute: "catatan")
     validation: Validation @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureType@validate")
     inboxFile: InboxFile @belongsTo
     documentSignatureSents: [DocumentSignatureSent]

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -11,7 +11,7 @@ type DocumentSignatureSent {
     next: String
     sender: People! @with(relation: "sender")
     receiver: People! @with(relation: "receiver")
-    previous: People! @with(relation: "previous")
+    previous: People @with(relation: "previous")
     read: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isRead")
     statusRead: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@statusRead")
     isLastSigned: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isLastSigned")


### PR DESCRIPTION
## Overview
- Add attachment attribute on document signature response

## Related Task
- https://app.clickup.com/t/2d31ua6

## ToDo
````
{
  documentSignatureSent(id: "XXX") {
    id
    documentSignature {
      id
      url
      attachment
      note
    }
    read
    note
    sender {
      name
    }
    receiver {
      name
    }
    previous {
      name
    }
  }
}
````

## Evidence
title: Add attachment attribute on document signature response
project: SIKD
participants: @indraprasetya154 