### PR TITLE
Enhance change link of qrcode esign

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -280,7 +280,7 @@ class DocumentSignatureMutator
         try {
             $addFooter = Http::post(config('sikd.add_footer_url'), [
                 'pdf' => $data->documentSignature->url,
-                'qrcode' => config('sikd.url') . 'v/' . $verifyCode,
+                'qrcode' => config('sikd.url') . 'verification/document/tte/' . $verifyCode . '?source=qrcode',
                 'category' => $data->documentSignature->documentSignatureType->document_paper_type,
                 'code' => $verifyCode
             ]);

--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -113,7 +113,7 @@ class DraftSignatureMutator
         try {
             $addFooter = Http::post(config('sikd.add_footer_url'), [
                 'pdf' => $draft->draft_file . '?esign=true',
-                'qrcode' => config('sikd.url') . 'v/' . $verifyCode,
+                'qrcode' => config('sikd.url') . 'verification/document/tte/' . $verifyCode . '?source=qrcode',
                 'category' => $draft->category_footer,
                 'code' => $verifyCode
             ]);


### PR DESCRIPTION
## Overview
- Enhance change link of qrcode esign
- Camera can't scan qrcode image (the main problem qrcode has an image in front of it)

## Related Task
- https://app.clickup.com/t/2d311at?comment=834757506

## Related PR
- https://gitlab.com/jdsteam/sikd-website/-/merge_requests/236

## Evidence
title: Add attachment attribute on document signature response
project: SIKD
participants: @indraprasetya154 