### PR TITLE
Add forward people id on document esign response

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
@@ -25,14 +25,9 @@ class DocumentSignatureRejectMutator
     public function reject($rootValue, array $args)
     {
         $documentSignatureSentId = Arr::get($args, 'input.documentSignatureSentId');
-        $note = Arr::get($args, 'input.note');
+        $note                    = Arr::get($args, 'input.note');
 
-        $documentSignatureSent = tap(DocumentSignatureSent::where('id', $documentSignatureSentId))->update([
-            'status' => SignatureStatusTypeEnum::REJECT()->value,
-            'catatan' => $note,
-            'tgl' => setDateTimeNowValue(),
-            'is_sender_read' => false
-        ])->first();
+        $documentSignatureSent = DocumentSignatureSent::where('id', $documentSignatureSentId)->first();
 
         if (!$documentSignatureSent) {
             throw new CustomException(
@@ -40,6 +35,13 @@ class DocumentSignatureRejectMutator
                 'Docuement with this id not found'
             );
         }
+
+        $documentSignatureSent->status              = SignatureStatusTypeEnum::REJECT()->value;
+        $documentSignatureSent->catatan             = $note;
+        $documentSignatureSent->tgl                 = setDateTimeNowValue();
+        $documentSignatureSent->is_sender_read      = false;
+        $documentSignatureSent->forward_receiver_id = $documentSignatureSent->PeopleID;
+        $documentSignatureSent->save();
 
         $this->doSendNotification($documentSignatureSentId);
 

--- a/src/app/Models/DocumentSignatureSent.php
+++ b/src/app/Models/DocumentSignatureSent.php
@@ -48,6 +48,11 @@ class DocumentSignatureSent extends Model
         return $this->belongsTo(People::class, 'previous_sender_id', 'PeopleId');
     }
 
+    public function forward()
+    {
+        return $this->belongsTo(People::class, 'forward_receiver_id', 'PeopleId');
+    }
+
     public function receiverPersonalAccessTokens()
     {
         return $this->hasMany(PersonalAccessToken::class, 'tokenable_id', 'PeopleIDTujuan');

--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -12,6 +12,7 @@ type DocumentSignatureSent {
     sender: People! @with(relation: "sender")
     receiver: People! @with(relation: "receiver")
     previous: People @with(relation: "previous")
+    forward: People @with(relation: "forward")
     read: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isRead")
     statusRead: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@statusRead")
     isLastSigned: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isLastSigned")


### PR DESCRIPTION
## Overview
- Add forward people id on document esign response
- Change forward people on reject document esign

## Related Task
- https://app.clickup.com/t/2d8fy18

## Related Pull Request
- Migration and changes on website https://gitlab.com/jdsteam/sikd-website/-/merge_requests/248

## Evidence
title: Set param on forward receiver after esign by drafter role
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214