### PR TITLE
Set forward target people id for gubernur and wakil gubernur role after last people esign

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -371,9 +371,11 @@ class DocumentSignatureMutator
                     $whereField = 'Code_Tu';
                     $whereParams = $documentSignatureSent->sender->role->Code_Tu;
                 }
-                $receiver = People::whereHas('role', function ($role) use ($whereField, $whereParams, $documentSignatureSent) {
+                $receiver = People::whereHas('role', function ($role) use ($whereField, $whereParams, $documentSignatureSent, $type) {
                     $role->where('RoleCode', $documentSignatureSent->sender->role->RoleCode);
-                    $role->where($whereField, $whereParams);
+                    if (($documentSignatureSent->sender->PrimaryRoleId != 'uk.1' || $documentSignatureSent->sender->PrimaryRoleId != 'uk.1.1.1') && $type != 'UK') {
+                        $role->where($whereField, $whereParams);
+                    }
                 })->where('GroupId', $peopleGroupType)->pluck('PeopleId');
                 break;
 


### PR DESCRIPTION
## Overview
- Set forward target people id for gubernur and wakil gubernur role after last people esign

## Related Task
- https://app.clickup.com/t/2dtxv8x

## Evidence
title: Set forward target people id for gubernur and wakil gubernur role after last people esign
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214