### PR TITLE
Create canDownload attribute for flagging download button at clients

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -42,14 +42,6 @@ class DocumentSignatureMutator
         if ($documentSignatureSent->status != SignatureStatusTypeEnum::WAITING()->value) {
             throw new CustomException('User already signed this document', 'Status of this document is already signed');
         }
-        $this->forwardReceiver($documentSignatureSent);
-        $checkParent = DocumentSignatureSent::where('ttd_id', $documentSignatureSent->ttd_id)
-            ->where('urutan', $documentSignatureSent->urutan - 1)
-            ->first();
-
-        if ($checkParent && $checkParent->status != SignatureStatusTypeEnum::SUCCESS()->value) {
-            throw new CustomException('Parent user is not already signed this document', 'Parent user of list signature assign is not already signed');
-        }
 
         $setupConfig = $this->setupConfigSignature();
         $file = $this->fileExist($documentSignatureSent->documentSignature->url);

--- a/src/app/Models/DocumentSignature.php
+++ b/src/app/Models/DocumentSignature.php
@@ -49,6 +49,14 @@ class DocumentSignature extends Model
         return false;
     }
 
+    public function getCanDownloadAttribute()
+    {
+        if (str_contains($this->url_public, 'sudah_ttd')) {
+            return true;
+        }
+        return false;
+    }
+
     public function getAttachmentAttribute()
     {
         if ($this->lampiran != null) {

--- a/src/graphql/documentSignature.graphql
+++ b/src/graphql/documentSignature.graphql
@@ -5,6 +5,7 @@ type DocumentSignature {
     createdAt: String @rename(attribute: "tanggal")
     updatedAt: String @rename(attribute: "tanggal_update")
     url: String @rename(attribute: "url_public")
+    canDownload: Boolean @rename(attribute: "canDownload")
     code: String
     attachment: String
     note: String @rename(attribute: "catatan")


### PR DESCRIPTION
## Overview 
- [Create `canDownload` attribute for flagging download button at clients](https://github.com/jabardigitalservice/office-services/commit/e4564b8613bf83f0cb4c796389299b37ae56f48a)
- Remove unused flow code (for check parent)

## Example Query
````
{
  documentSignatureSent(id: "xxx") {
    id
    documentSignature {
      id
      url
      canDownload
      attachment
      note
    }
    read
    next
    note
    sender {
      name
    }
    receiver {
      name
    }
    previous {
      name
    }
    forward {
      name
    }
  }
}
````

## Related Task
- https://app.clickup.com/t/2h6e9xx

## Evidence
title: Create canDownload attribute for flagging download button at clients
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214 