### PR TITLE
fix: change file upload esign method from pdf byte to upload new file

### DIFF
--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -74,7 +74,11 @@ class DraftSignatureMutator
     {
         $url = $setupConfig['url'] . '/api/sign/pdf';
         $verifyCode = strtoupper(substr(sha1(uniqid(mt_rand(), true)), 0, 10));
+        $tmpFileFooterName = 'FOOTER_' . $draft->document_file_name;
         $pdfFile = $this->addFooterDocument($draft, $verifyCode);
+
+        Storage::disk('local')->put($tmpFileFooterName, $pdfFile);
+        $pdfFile = fopen(Storage::path($tmpFileFooterName), 'r');
 
         $response = Http::withHeaders([
             'Authorization' => 'Basic ' . $setupConfig['auth'],
@@ -85,6 +89,8 @@ class DraftSignatureMutator
             'tampilan'      => 'invisible',
             'image'         => 'false',
         ]);
+
+        Storage::disk('local')->delete($tmpFileFooterName);
 
         if ($response->status() != Response::HTTP_OK) {
             $bodyResponse = json_decode($response->body());


### PR DESCRIPTION
## Overview 
- fix: change file upload esign method from pdf byte to upload new file

## Evidence
title: fix: change file upload esign method from pdf byte to upload new file
project: SIKD
participants: @indraprasetya154 @samudra-ajri 