### PR TITLE
Change fopen to file_get_contents on upload footer file esign

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -76,7 +76,7 @@ class DocumentSignatureMutator
         $pdfFile = $this->pdfFile($data, $verifyCode);
         if ($data->documentSignature->has_footer == false) {
             Storage::disk('local')->put($tmpFileFooterName, $pdfFile);
-            $pdfFile = fopen(Storage::path($tmpFileFooterName), 'r');
+            $pdfFile = file_get_contents(Storage::path($tmpFileFooterName), 'r');
         }
 
         $response = Http::withHeaders([

--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -78,7 +78,7 @@ class DraftSignatureMutator
         $pdfFile = $this->addFooterDocument($draft, $verifyCode);
 
         Storage::disk('local')->put($tmpFileFooterName, $pdfFile);
-        $pdfFile = fopen(Storage::path($tmpFileFooterName), 'r');
+        $pdfFile = file_get_contents(Storage::path($tmpFileFooterName), 'r');
 
         $response = Http::withHeaders([
             'Authorization' => 'Basic ' . $setupConfig['auth'],


### PR DESCRIPTION
## Overview 
- fix: Change fopen to file_get_contents on upload footer file esign

## Evidence
title: fix: Change fopen to file_get_contents on upload footer file esign
project: SIKD
participants: @indraprasetya154 @samudra-ajri 