### PR TITLE
Modify fulltext search into boolean mode

### DIFF
--- a/src/app/Models/InboxReceiver.php
+++ b/src/app/Models/InboxReceiver.php
@@ -130,8 +130,8 @@ class InboxReceiver extends Model
                     ->select('NId')
                     ->from('inbox')
                     ->whereRaw(
-                        'MATCH(Hal) AGAINST(? IN NATURAL LANGUAGE MODE)',
-                        [$search]
+                        'MATCH(Hal) AGAINST(? IN BOOLEAN MODE)',
+                        [$search . '*']
                     )
             );
         }


### PR DESCRIPTION
## Overview
- This modification will rsults the filter with the word prefix.
-  For example, we have a sentence: 'The coconut export trend', then the input search keyword is 'expo'.
- With `NATURAL LANGUAGE` mode it will return nothing. Differently, it could be matched if we use `BOOLEAN MODE`.

## Evidence
title: Modify fulltext search into boolean mode
project: SIKD
participants: @samudra-ajri @azophy 