### PR TITLE
fix: add reject status to document after reject esign

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
@@ -45,9 +45,9 @@ class DocumentSignatureRejectMutator
         $documentSignatureSent->forward_receiver_id = $documentSignatureSent->PeopleID;
         $documentSignatureSent->save();
 
-        $documentSignature = DocumentSignature::where('id', $documentSignatureSent->ttd_id)->first();
-        $documentSignature->status = SignatureStatusTypeEnum::REJECT()->value;
-        $documentSignature->save();
+        DocumentSignature::where('id', $documentSignatureSent->ttd_id)->update([
+            'status' => SignatureStatusTypeEnum::REJECT()->value,
+        ]);
 
         $this->doSendNotification($documentSignatureSentId);
 

--- a/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureRejectMutator.php
@@ -8,6 +8,7 @@ use App\Enums\SignatureStatusTypeEnum;
 use App\Enums\StatusReadTypeEnum;
 use App\Http\Traits\SendNotificationTrait;
 use App\Exceptions\CustomException;
+use App\Models\DocumentSignature;
 use App\Models\DocumentSignatureSent;
 use Illuminate\Support\Arr;
 
@@ -43,6 +44,10 @@ class DocumentSignatureRejectMutator
         $documentSignatureSent->is_sender_read      = false;
         $documentSignatureSent->forward_receiver_id = $documentSignatureSent->PeopleID;
         $documentSignatureSent->save();
+
+        $documentSignature = DocumentSignature::where('id', $documentSignatureSent->ttd_id)->first();
+        $documentSignature->status = SignatureStatusTypeEnum::REJECT()->value;
+        $documentSignature->save();
 
         $this->doSendNotification($documentSignatureSentId);
 


### PR DESCRIPTION
## Overview
- fix: add reject status to document after reject esign

## Related Task
- https://app.clickup.com/t/2kpm3tb

## Evidence
title: fix: add reject status to document after reject esign
project: SIKD
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214 @azophy 