### PR TITLE
feat: un-delete draft file after last people signed the document

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -247,6 +247,9 @@ class DocumentSignatureMutator
                 //Send notification to next people
                 $this->doSendNotification($nextDocumentSent->id);
             } else { // if this is last people
+                $updateFileData = DocumentSignature::where('id', $data->ttd_id)->update([
+                    'status' => SignatureStatusTypeEnum::SUCCESS()->value,
+                ]);
                 $documentSignatureForwardIds = $this->doForward($data);
                 if (!$documentSignatureForwardIds) {
                     throw new CustomException(

--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -247,9 +247,6 @@ class DocumentSignatureMutator
                 //Send notification to next people
                 $this->doSendNotification($nextDocumentSent->id);
             } else { // if this is last people
-                $updateFileData = DocumentSignature::where('id', $data->ttd_id)->update([
-                    'status' => SignatureStatusTypeEnum::SUCCESS()->value,
-                ]);
                 $documentSignatureForwardIds = $this->doForward($data);
                 if (!$documentSignatureForwardIds) {
                     throw new CustomException(

--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -177,18 +177,12 @@ class DocumentSignatureMutator
         if ($data->urutan == 1) {
             $documentRequest['first_tier'] = true;
         }
-        // check if this esign is last tier
-        $nextDocumentSent = $this->findNextDocumentSent($data);
-        if (!$nextDocumentSent) {
-            $documentRequest['last_tier'] = true;
-            $documentRequest['document_name'] = $data->documentSignature->tmp_draft_file;
-        }
 
         $fileSignatured = fopen(Storage::path($newFileName), 'r');
         /**
          * This code will running :
          * Transfer file to service existing
-         * Remove original file (first tier) and original with draft label file (last tier)
+         * Remove original file (first tier)
         **/
         $response = Http::withHeaders([
             'Secret' => config('sikd.webhook_secret'),


### PR DESCRIPTION
## Overview
- [feat: un-delete draft file after last people signed the document](https://github.com/jabardigitalservice/office-services/pull/454/commits/231caccdd18a1cc224fcb171f314d17c24f3df72)
- draft file will be deleted after registered document (new feature)

## Related Task
- https://app.clickup.com/t/2nfy848

## Evidence
title: feat: un-delete draft file after last people signed the document
project: SIKD
participants: @indraprasetya154 @samudra-ajri @azophy @fajarhikmal214 