### PR TITLE
feat: change schema forward document to uk/tu after registered document on website

### DIFF
--- a/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DocumentSignatureMutator.php
@@ -250,13 +250,6 @@ class DocumentSignatureMutator
                 $updateFileData = DocumentSignature::where('id', $data->ttd_id)->update([
                     'status' => SignatureStatusTypeEnum::SUCCESS()->value,
                 ]);
-                $documentSignatureForwardIds = $this->doForward($data);
-                if (!$documentSignatureForwardIds) {
-                    throw new CustomException(
-                        'Forward document failed',
-                        'Return ids is missing. Please try again.'
-                    );
-                }
                 //Send notification to sender
                 $this->doSendForwardNotification($data->id, $data->receiver->PeopleName);
             }


### PR DESCRIPTION
## Overview
- feat: change schema forward document to uk/tu after registered document on website
- forward to UK/TU will be forwarded after registered document (new feature)

## Related Task
- https://app.clickup.com/t/2nfyvvq

## Evidence
title:feat: change schema forward document to uk/tu after registered document on website
project: SIKD
participants: @indraprasetya154 @azophy @samudra-ajri @fajarhikmal214 