### PR TITLE
Modify the kafka message sending method

### DIFF
--- a/src/app/Http/Traits/KafkaTrait.php
+++ b/src/app/Http/Traits/KafkaTrait.php
@@ -33,7 +33,8 @@ trait KafkaTrait
 
         $message = new Message(body: $data);
         /** @var \Junges\Kafka\Producers\ProducerBuilder $producer */
-        $producer = Kafka::publishOn($topic)->withMessage($message);
+        // $producer = Kafka::publishOn($topic)->withMessage($message);
+        $producer = Kafka::publishOn('topic')->withBodyKey('medium', 'mobile');
         $producer->send();
     }
 }


### PR DESCRIPTION
## Overview
Modify method from `withMessage` to `withBodyKey`.

## Evidence
title: Modify the kafka message sending method
project: SIKD
participants: @samudra-ajri @indraprasetya154