### PR TITLE
Modify inbox condition for no role users

### DIFF
--- a/src/app/Http/Traits/InboxFilterTrait.php
+++ b/src/app/Http/Traits/InboxFilterTrait.php
@@ -225,8 +225,8 @@ trait InboxFilterTrait
             $this->queryInternalScopeGovernor($query);
         } elseif ($receiverTypes && $arrayReceiverTypes[0] == 'to_forward') {
             $query->whereRelation('sender', 'GroupId', '!=', PeopleGroupTypeEnum::UK());
-        } else {
-            $query->whereRelation('sender.role', 'RoleCode', '=', auth()->user()->role?->RoleCode);
+        } elseif (auth()->user()->role?->RoleCode) {
+            $query->whereRelation('sender.role', 'RoleCode', '=', auth()->user()->role->RoleCode);
         }
     }
 


### PR DESCRIPTION
## Overview
This modification will return no filter inboxes for user that have no role.

## Evidence
title: Modify inbox condition for no role users
project: SIKD
participants: @samudra-ajr
