### PR TITLE
Add has logged user checker end point

### DIFF
--- a/src/app/Http/Controllers/V1/ListLoggedUsers.php
+++ b/src/app/Http/Controllers/V1/ListLoggedUsers.php
@@ -20,10 +20,9 @@ class ListLoggedUsers extends Controller
     {
         $authHeader = $request->header('Authorization');
         if (!$authHeader || $authHeader != 'Basic ' . config('personalaccesstoken.auth_key')) {
-            throw new CustomException(
-                'Invalid header',
-                'Invalid authorization, please insert a valid authorization header'
-            );
+            return response()->json([
+                'message' => 'Unauthorized',
+            ], 401);
         }
 
         $idNumber = $request->idNumber; // idNumber is a NIK or NIP
@@ -34,8 +33,13 @@ class ListLoggedUsers extends Controller
 
         $hasLogged = PersonalAccessToken::where('tokenable_id', $userId?->PeopleId)->exists();
         if (!$hasLogged) {
-            return ['message' => 'User has no logged'];
+            return response()->json([
+                'message' => 'No logged user found'
+            ], 404);
         }
-        return ['message' => 'User has logged'];
+
+        return response()->json([
+            'message' => 'User has logged',
+        ], 200);
     }
 }

--- a/src/app/Http/Controllers/V1/ListLoggedUsers.php
+++ b/src/app/Http/Controllers/V1/ListLoggedUsers.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Controllers\V1;
+
+use App\Exceptions\CustomException;
+use App\Http\Controllers\Controller;
+use App\Models\People;
+use App\Models\PersonalAccessToken;
+use Illuminate\Http\Request;
+
+class ListLoggedUsers extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request)
+    {
+        $authHeader = $request->header('Authorization');
+        if (!$authHeader || $authHeader != 'Basic ' . config('personalaccesstoken.auth_key')) {
+            throw new CustomException(
+                'Invalid header',
+                'Invalid authorization, please insert a valid authorization header'
+            );
+        }
+
+        $idNumber = $request->idNumber; // idNumber is a NIK or NIP
+        $userId = People::select('PeopleId')
+            ->where('NIK', $idNumber)
+            ->orWhere('NIP', $idNumber)
+            ->first();
+
+        $hasLogged = PersonalAccessToken::where('tokenable_id', $userId?->PeopleId)->exists();
+        if (!$hasLogged) {
+            return ['message' => 'User has no logged'];
+        }
+        return ['message' => 'User has logged'];
+    }
+}

--- a/src/config/personalaccesstoken.php
+++ b/src/config/personalaccesstoken.php
@@ -1,0 +1,5 @@
+<?php
+
+return [
+    'auth_key' => env('LOGGED_PERSONALACCESSTOKEN_AUTH_KEY'),
+];

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\V1\SendNotificationController;
 use App\Http\Controllers\V1\DocumentDraftPdfController;
+use App\Http\Controllers\V1\ListLoggedUsers;
 use App\Http\Controllers\V1\LogUserActivityController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -25,4 +26,5 @@ Route::prefix('v1')->group(function () {
     Route::post('/send-notification', [SendNotificationController::class, '__invoke']);
     Route::post('/log-user-activity', [LogUserActivityController::class, '__invoke']);
     Route::get('/draft/{id}', [DocumentDraftPdfController::class, '__invoke']);
+    Route::get('/users/{idNumber}/haslogged', [ListLoggedUsers::class, '__invoke']);
 });

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,7 +2,7 @@
 
 use App\Http\Controllers\V1\SendNotificationController;
 use App\Http\Controllers\V1\DocumentDraftPdfController;
-use App\Http\Controllers\V1\ListLoggedUsers;
+use App\Http\Controllers\V1\LoggedUserCheckController;
 use App\Http\Controllers\V1\LogUserActivityController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -26,5 +26,5 @@ Route::prefix('v1')->group(function () {
     Route::post('/send-notification', [SendNotificationController::class, '__invoke']);
     Route::post('/log-user-activity', [LogUserActivityController::class, '__invoke']);
     Route::get('/draft/{id}', [DocumentDraftPdfController::class, '__invoke']);
-    Route::get('/users/{idNumber}/haslogged', [ListLoggedUsers::class, '__invoke']);
+    Route::get('/users/{idNumber}/haslogged', [LoggedUserCheckController::class, '__invoke']);
 });


### PR DESCRIPTION
## Overview
- This api tells if a user have ever logged in sidebar mobile or not
- The checking proccess uses the user `idNumber` (NIK/NIP)
- Because it is sperated from GraphQL service but still need a security, then a basic auth on the request  header is implemented

## ToDo
- [x] Add `LOGGED_PERSONALACCESSTOKEN_AUTH_KEY` variable on the env server

## Evidence
title: Add has logged user checker end point
project: SIKD
participants: @samudra-ajri @indraprasetya154  @fajarhikmal214 @azophy 