### PR TITLE
Add download signatured document file service

### DIFF
--- a/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
+++ b/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
@@ -16,49 +16,66 @@ class SignaturedDocumentDownloadController extends Controller
      * Handle the incoming request.
      *
      * @param  \Illuminate\Http\Request  $request
+     * @param  String $id
      * @return \Illuminate\Http\Response
      */
     public function __invoke(Request $request, $id)
     {
-        $document = DocumentSignature::find($id);
-        if (!$document) {
-            $this->kafkaPublish('analytic_event', [
-                'event' => 'download_signed_letter',
-                'status' => KafkaStatusTypeEnum::FAILED()
-            ]);
+        $logData = [
+            'event' => 'download_signed_letter',
+            'status' => KafkaStatusTypeEnum::SUCCESS(),
+        ];
 
+        $document = DocumentSignature::find($id);
+        if ($document) {
+            $file = $this->generateFile($document);
+            $logData['letter']['file'] = $file;
+            $this->kafkaPublish('analytic_event', $logData);
+            return response()->json([
+                'file' => $file
+            ], 200);
+        } else {
+            $logData['status'] = KafkaStatusTypeEnum::FAILED();
+            $this->kafkaPublish('analytic_event', $logData);
             return response()->json([
                 'message' => 'Document not found'
             ], 404);
         }
+    }
 
+    /**
+     * Generate document file.
+     *
+     * @param  DocumentSignature $document
+     * @return String
+     */
+    protected function generateFile($document)
+    {
         $path = config('sikd.base_path_file');
-        // New data with registered flow
-        if ($document->is_registered === true) {
-            $file = $path . 'ttd/sudah_ttd/' . $document->file;
-        } elseif ($document->is_registered === false && $document->is_registered !== null) {
-            $file = $path . 'ttd/draft/' . $document->tmp_draft_file;
-        } else {
-            // Old data without registered flow
-            $file = $document->checkFile($path . 'ttd/draft/' . $document->tmp_draft_file);
-            if ($file === false) {
-                $file = $document->checkFile($path . 'ttd/sudah_ttd/' . $document->file);
-                if ($file === false) { // handle for old data before draft schema implemented
-                    $file = $path . 'ttd/blm_ttd/' . $document->file;
-                }
+        $file = match ($document->is_registered) {
+            (int) true => $path . 'ttd/sudah_ttd/' . $document->file,
+            (int) false => $file = $path . 'ttd/draft/' . $document->tmp_draft_file,
+            default => $this->generateFileWhichRegisteredStatusNull($document)
+        };
+        return $file;
+    }
+
+    /**
+     * Generate document file which has null registered status.
+     *
+     * @param  DocumentSignature $document
+     * @return String
+     */
+    protected function generateFileWhichRegisteredStatusNull($document)
+    {
+        $path = config('sikd.base_path_file');
+        $file = $document->checkFile($path . 'ttd/draft/' . $document->tmp_draft_file);
+        if ($file === false) {
+            $file = $document->checkFile($path . 'ttd/sudah_ttd/' . $document->file);
+            if ($file === false) { // handle for old data before draft schema implemented
+                $file = $path . 'ttd/blm_ttd/' . $document->file;
             }
         }
-
-        $this->kafkaPublish('analytic_event', [
-            'event' => 'download_signed_letter',
-            'status' => KafkaStatusTypeEnum::SUCCESS(),
-            'letter' => [
-                'file' => $file
-            ]
-        ]);
-
-        return response()->json([
-            'file' => $file
-        ], 200);
+        return $file;
     }
 }

--- a/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
+++ b/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
@@ -28,7 +28,7 @@ class SignaturedDocumentDownloadController extends Controller
 
         $document = DocumentSignature::find($id);
         if ($document) {
-            $file = $this->generateFile($document);
+            $file = $document->getUrlPublicAttribute();
             $logData['letter']['file'] = $file;
             $this->kafkaPublish('analytic_event', $logData);
             // download document file
@@ -44,41 +44,5 @@ class SignaturedDocumentDownloadController extends Controller
                 'message' => 'Document not found'
             ], 404);
         }
-    }
-
-    /**
-     * Generate document file.
-     *
-     * @param  DocumentSignature $document
-     * @return String
-     */
-    protected function generateFile($document)
-    {
-        $path = config('sikd.base_path_file');
-        $file = match ($document->is_registered) {
-            (int) true => $path . 'ttd/sudah_ttd/' . $document->file,
-            (int) false => $file = $path . 'ttd/draft/' . $document->tmp_draft_file,
-            default => $this->generateFileWhichRegisteredStatusNull($document)
-        };
-        return $file;
-    }
-
-    /**
-     * Generate document file which has null registered status.
-     *
-     * @param  DocumentSignature $document
-     * @return String
-     */
-    protected function generateFileWhichRegisteredStatusNull($document)
-    {
-        $path = config('sikd.base_path_file');
-        $file = $document->checkFile($path . 'ttd/draft/' . $document->tmp_draft_file);
-        if ($file === false) {
-            $file = $document->checkFile($path . 'ttd/sudah_ttd/' . $document->file);
-            if ($file === false) { // handle for old data before draft schema implemented
-                $file = $path . 'ttd/blm_ttd/' . $document->file;
-            }
-        }
-        return $file;
     }
 }

--- a/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
+++ b/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
@@ -36,6 +36,7 @@ class SignaturedDocumentDownloadController extends Controller
             ], 200);
         } else {
             $logData['status'] = KafkaStatusTypeEnum::FAILED();
+            $logData['message'] = 'Document not found';
             $this->kafkaPublish('analytic_event', $logData);
             return response()->json([
                 'message' => 'Document not found'

--- a/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
+++ b/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\V1;
+
+use App\Http\Controllers\Controller;
+use App\Models\DocumentSignature;
+use Illuminate\Http\Request;
+
+class SignaturedDocumentDownloadController extends Controller
+{
+    /**
+     * Handle the incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @return \Illuminate\Http\Response
+     */
+    public function __invoke(Request $request, $id)
+    {
+        $document = DocumentSignature::find($id);
+        if (!$document) {
+            return response()->json([
+                'message' => 'Document not found'
+            ], 404);
+        }
+
+        $path = config('sikd.base_path_file');
+        // New data with registered flow
+        if ($document->is_registered === true) {
+            $file = $path . 'ttd/sudah_ttd/' . $document->file;
+        } elseif ($document->is_registered === false && $document->is_registered !== null) {
+            $file = $path . 'ttd/draft/' . $document->tmp_draft_file;
+        } else {
+            // Old data without registered flow
+            $file = $document->checkFile($path . 'ttd/draft/' . $document->tmp_draft_file);
+            if ($file === false) {
+                $file = $document->checkFile($path . 'ttd/sudah_ttd/' . $document->file);
+                if ($file === false) { // handle for old data before draft schema implemented
+                    $file = $path . 'ttd/blm_ttd/' . $document->file;
+                }
+            }
+        }
+
+        return response()->json([
+            'file' => $file
+        ], 200);
+    }
+}

--- a/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
+++ b/src/app/Http/Controllers/V1/SignaturedDocumentDownloadController.php
@@ -31,9 +31,11 @@ class SignaturedDocumentDownloadController extends Controller
             $file = $this->generateFile($document);
             $logData['letter']['file'] = $file;
             $this->kafkaPublish('analytic_event', $logData);
-            return response()->json([
-                'file' => $file
-            ], 200);
+            // download document file
+            $filename = $document->file;
+            $tempFile = tempnam(sys_get_temp_dir(), $filename);
+            copy($file, $tempFile);
+            return response()->download($tempFile, $filename);
         } else {
             $logData['status'] = KafkaStatusTypeEnum::FAILED();
             $logData['message'] = 'Document not found';

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -20,14 +20,19 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/user', function (Request $request) {
+        return $request->user();
+    });
+    Route::prefix('v1')->group(function () {
+        Route::get('/signatured-documents/{id}/file', [SignaturedDocumentDownloadController::class, '__invoke']);
+    });
 });
+
 
 Route::prefix('v1')->group(function () {
     Route::post('/send-notification', [SendNotificationController::class, '__invoke']);
     Route::post('/log-user-activity', [LogUserActivityController::class, '__invoke']);
     Route::get('/draft/{id}', [DocumentDraftPdfController::class, '__invoke']);
     Route::get('/users/{idNumber}/haslogged', [LoggedUserCheckController::class, '__invoke']);
-    Route::get('/signatured-documents/{id}/file', [SignaturedDocumentDownloadController::class, '__invoke']);
 });

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -24,7 +24,7 @@ Route::middleware('auth:sanctum')->group(function () {
         return $request->user();
     });
     Route::prefix('v1')->group(function () {
-        Route::get('/signatured-documents/{id}/file', [SignaturedDocumentDownloadController::class, '__invoke']);
+        Route::get('/signatured-documents/{id}/download', [SignaturedDocumentDownloadController::class, '__invoke']);
     });
 });
 

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,8 +2,10 @@
 
 use App\Http\Controllers\V1\SendNotificationController;
 use App\Http\Controllers\V1\DocumentDraftPdfController;
+use App\Http\Controllers\V1\InboxDocumentDownloadController;
 use App\Http\Controllers\V1\LoggedUserCheckController;
 use App\Http\Controllers\V1\LogUserActivityController;
+use App\Http\Controllers\V1\SignaturedDocumentDownloadController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -27,4 +29,5 @@ Route::prefix('v1')->group(function () {
     Route::post('/log-user-activity', [LogUserActivityController::class, '__invoke']);
     Route::get('/draft/{id}', [DocumentDraftPdfController::class, '__invoke']);
     Route::get('/users/{idNumber}/haslogged', [LoggedUserCheckController::class, '__invoke']);
+    Route::get('/signatured-documents/{id}/file', [SignaturedDocumentDownloadController::class, '__invoke']);
 });

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -2,7 +2,6 @@
 
 use App\Http\Controllers\V1\SendNotificationController;
 use App\Http\Controllers\V1\DocumentDraftPdfController;
-use App\Http\Controllers\V1\InboxDocumentDownloadController;
 use App\Http\Controllers\V1\LoggedUserCheckController;
 use App\Http\Controllers\V1\LogUserActivityController;
 use App\Http\Controllers\V1\SignaturedDocumentDownloadController;

--- a/src/routes/api.php
+++ b/src/routes/api.php
@@ -29,7 +29,6 @@ Route::middleware('auth:sanctum')->group(function () {
     });
 });
 
-
 Route::prefix('v1')->group(function () {
     Route::post('/send-notification', [SendNotificationController::class, '__invoke']);
     Route::post('/log-user-activity', [LogUserActivityController::class, '__invoke']);


### PR DESCRIPTION
## Overview
- Add signatured document file download api. This api is needed beacuse graphQL can not handle file download service.
- Download file from url.
- Add log activity: download signatured letter.

## Evidence
title: Add download signatured document file service
project: SIKD
participants: @samudra-ajri @indraprasetya154 @fajarhikmal214  @wanzismail 