### PR TITLE
Add inbox filter by the sender depts ids

### DIFF
--- a/src/app/Http/Traits/InboxFilterTrait.php
+++ b/src/app/Http/Traits/InboxFilterTrait.php
@@ -331,7 +331,7 @@ trait InboxFilterTrait
     }
 
     /**
-     * Filtering by sender's dept name
+     * Filtering by the sender depts ids
      *
      * @param Object $query
      * @param Array  $filter

--- a/src/app/Http/Traits/InboxFilterTrait.php
+++ b/src/app/Http/Traits/InboxFilterTrait.php
@@ -331,6 +331,27 @@ trait InboxFilterTrait
     }
 
     /**
+     * Filtering by sender's dept name
+     *
+     * @param Object $query
+     * @param Array  $filter
+     *
+     * @return Void
+     */
+    private function filterBySenderDepts($query, $filter)
+    {
+        $deptsIds = $filter['senderDepts'] ?? null;
+        if ($deptsIds) {
+            $arrayIds = explode(", ", $deptsIds);
+            $query->whereIn('From_Id', fn($query) => $query->select('PeopleId')
+                ->from('people')
+                ->whereIn('PrimaryRoleId', fn($query) => $query->select('RoleId')
+                    ->from('role')
+                    ->whereIn('RoleCode', $arrayIds)));
+        }
+    }
+
+    /**
      * Followed up status filter determination
      *
      * @param Object $query

--- a/src/app/Models/InboxReceiver.php
+++ b/src/app/Models/InboxReceiver.php
@@ -120,6 +120,7 @@ class InboxReceiver extends Model
         $this->filterByScope($query, $filter);
         $this->filterByFollowedUpStatus($query, $filter);
         $this->filterByActionLabel($query, $filter);
+        $this->filterBySenderDepts($query, $filter);
         return $query;
     }
 

--- a/src/graphql/inboxReceiver.graphql
+++ b/src/graphql/inboxReceiver.graphql
@@ -33,6 +33,7 @@ input FilterInput {
     followedUp: String
     scope: ScopeType
     actionLabels: String
+    senderDepts: String
 }
 
 input ForwardInput {


### PR DESCRIPTION
## Overview
The inboxes list will be filtered by the sender departments ids.

## Related Link
Task: https://app.clickup.com/t/307a1tu

## Gql query example
```
inboxes(
    first: 20
    filter: {
      scope: INTERNAL
      receiverTypes: ""
      statuses: ""
      senderDepts: "3"
  }
)
```

## Evidence
title: Add inbox filter by the sender depts ids
project: SIKD
participants: @samudra-ajri @indraprasetya154 @fajarhikmal214 