### PR TITLE
Modify sender depts inbox filter

### DIFF
--- a/src/app/Http/Traits/InboxFilterTrait.php
+++ b/src/app/Http/Traits/InboxFilterTrait.php
@@ -334,11 +334,13 @@ trait InboxFilterTrait
         $deptsIds = $filter['senderDepts'] ?? null;
         if ($deptsIds) {
             $arrayIds = explode(", ", $deptsIds);
-            $query->whereIn('From_Id', fn($query) => $query->select('PeopleId')
-                ->from('people')
-                ->whereIn('PrimaryRoleId', fn($query) => $query->select('RoleId')
-                    ->from('role')
-                    ->whereIn('RoleCode', $arrayIds)));
+            $query->whereIn('NId', fn($query) => $query->select('NId')
+                ->from('inbox')
+                ->whereIn('createdBy', fn($query) => $query->select('PeopleId')
+                    ->from('people')
+                    ->whereIn('PrimaryRoleId', fn($query) => $query->select('RoleId')
+                        ->from('role')
+                        ->whereIn('RoleCode', $arrayIds))));
         }
     }
 


### PR DESCRIPTION
## Overview
The previous filter is based on 'From_Id' field. Otherwise, it should use the 'createdBy' field from the inbox detail.

## Related Link
Task: https://app.clickup.com/t/307a1tu

## Evidence
title: Modify sender depts inbox filter
project: SIKD
participants: @samudra-ajri @indraprasetya154 @fajarhikmal214 