### PR TITLE
Modify inbox filter by OPD

### DIFF
--- a/src/app/Http/Traits/InboxFilterTrait.php
+++ b/src/app/Http/Traits/InboxFilterTrait.php
@@ -334,13 +334,14 @@ trait InboxFilterTrait
         $deptsIds = $filter['senderDepts'] ?? null;
         if ($deptsIds) {
             $arrayIds = explode(", ", $deptsIds);
-            $query->whereIn('NId', fn($query) => $query->select('NId')
-                ->from('inbox')
-                ->whereIn('createdBy', fn($query) => $query->select('PeopleId')
-                    ->from('people')
-                    ->whereIn('PrimaryRoleId', fn($query) => $query->select('RoleId')
-                        ->from('role')
-                        ->whereIn('RoleCode', $arrayIds))));
+            $query->leftJoin('inbox', 'inbox_receiver.NId', '=', 'inbox.NId')
+                ->leftJoin('people', 'inbox.createdBy', '=', 'people.PeopleId')
+                ->leftJoin('role', 'people.PrimaryRoleId', '=', 'role.RoleId')
+                ->where(
+                    fn($query) => $query
+                        ->whereIn('role.roleCode', $arrayIds)
+                        ->orWhereIn('inbox.InstansiPengirimId', $arrayIds)
+                );
         }
     }
 


### PR DESCRIPTION
## Overview
This filter has two behaviours, there are filtering by the `createdBy` and the `InstansiPengirimId` attributes when the letter is a forwarded or internal-registered letter respectively.

## Evidence
title: Modify inbox filter by sender depts
project: SIKD
participants: @samudra-ajri 