### PR TITLE
feat: add status queue at query document detail

### DIFF
--- a/src/graphql/documentSignatureSent.graphql
+++ b/src/graphql/documentSignatureSent.graphql
@@ -17,6 +17,7 @@ type DocumentSignatureSent {
     statusRead: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@statusRead")
     senderRead: Boolean @rename(attribute: "is_sender_read")
     receiverRead: Boolean @rename(attribute: "is_receiver_read")
+    progressQueue: String @rename(attribute: "progress_queue")
     isLastSigned: Boolean @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@isLastSigned")
     parent: DocumentSignatureSent @field(resolver: "App\\GraphQL\\Types\\DocumentSignatureSentType@parent")
     documentSignature: DocumentSignature @with(relation: "documentSignature")


### PR DESCRIPTION
## Overview
- feat: add status queue at query document detail

## Status Progress Query
 * WAITING
 * PROCESS
 * DONE
 * FAILED
 
## Example Query
````
{
  documentSignatureSentMultiple(
    documentSignatureSentIds: "XXX, ZZZ"
  ) {
      id
      status
      progressQueue
  }
}
````

## Evidence
title: feat: add status queue at query document detail
project: SIKD
participants: @indraprasetya154 @fajarhikmal214 @samudra-ajri 