### PR TITLE
Modify filter by OPD

### DIFF
--- a/src/app/Http/Traits/InboxFilterTrait.php
+++ b/src/app/Http/Traits/InboxFilterTrait.php
@@ -340,6 +340,7 @@ trait InboxFilterTrait
                 ->where(
                     fn($query) => $query
                         ->whereIn('role.roleCode', $arrayIds)
+                        ->whereNull('inbox.InstansiPengirimId')
                         ->orWhereIn('inbox.InstansiPengirimId', $arrayIds)
                 );
         }

--- a/src/graphql/inbox.graphql
+++ b/src/graphql/inbox.graphql
@@ -18,6 +18,8 @@ type Inbox {
     documentPath: String @rename(attribute: "NFileDir")
     documentFile: InboxFile @belongsTo
     documentUrlPublic: String @rename(attribute: "url_public")
+    deptSenderId: String @rename(attribute: "InstansiPengirimId")
+    deptSenderName: String @rename(attribute: "Instansipengirim")
     attachment: String
 }
 


### PR DESCRIPTION
## Overview
- add opd sender id and name attribute to iInbox type
- modify filter by OPD to check if the sender is null

## Evidence
title: Modify filter by OPD
project: SIKD
participants: @samudra-ajri @indraprasetya154 