### PR TITLE
fix: invalid response document file if user used upload file (attachment) on drafting module

### DIFF
--- a/src/app/Enums/InboxFileTypeEnum.php
+++ b/src/app/Enums/InboxFileTypeEnum.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace App\Enums;
+
+use Spatie\Enum\Enum;
+
+/**
+ * @method static self ATTACHMENT_DOCUMENT()
+ */
+
+final class InboxFileTypeEnum extends Enum
+{
+
+}

--- a/src/app/GraphQL/Mutations/DraftSignatureMutator.php
+++ b/src/app/GraphQL/Mutations/DraftSignatureMutator.php
@@ -133,7 +133,7 @@ class DraftSignatureMutator
         try {
             $addFooter = Http::attach(
                 'pdf',
-                file_get_contents($draft->draft_file . '?esign=true'),
+                file_get_contents($draft->draft_file_for_esign . '?esign=true'),
                 $draft->document_file_name
             )->post(config('sikd.add_footer_url'), [
                 'qrcode' => config('sikd.url') . 'verification/document/tte/' . $verifyCode . '?source=qrcode',

--- a/src/app/Models/Draft.php
+++ b/src/app/Models/Draft.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Enums\InboxFileTypeEnum;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -77,14 +78,34 @@ class Draft extends Model
         return $this->belongsTo(InboxFile::class, 'NId_Temp', 'NId');
     }
 
+    public function documentDraftFile()
+    {
+        return $this->inboxFile()->where('Keterangan', '!=',  InboxFileTypeEnum::ATTACHMENT_DOCUMENT());
+    }
+
+    public function inboxFiles()
+    {
+        return $this->hasMany(InboxFile::class, 'NId', 'NId_Temp');
+    }
+
+    public function attachments()
+    {
+        return $this->inboxFiles()->where('Keterangan', InboxFileTypeEnum::ATTACHMENT_DOCUMENT());
+    }
+
     public function getDraftFileAttribute()
     {
         $file = URL::to('/api/v1/draft/' . $this->NId_Temp);
-        if ($this->inboxFile) {
-            $file = config('sikd.base_path_file_letter') . $this->inboxFile->FileName_fake;
+        if ($this->documentDraftFile) {
+            $file = $this->inboxFile->url;
         }
 
         return $file;
+    }
+
+    public function getDraftFileForEsignAttribute()
+    {
+        return URL::to('/api/v1/draft/' . $this->NId_Temp);
     }
 
     public function getUrlPublicAttribute()

--- a/src/app/Models/InboxFile.php
+++ b/src/app/Models/InboxFile.php
@@ -38,6 +38,11 @@ class InboxFile extends Model
         return $query;
     }
 
+    public function getUrlAttribute()
+    {
+        return config('sikd.base_path_file_letter') . $this->FileName_fake;
+    }
+
     public function setEditedDateAttribute($value)
     {
         $this->attributes['EditedDate'] = $value->copy()->setTimezone(config('sikd.timezone_server'));

--- a/src/graphql/draft.graphql
+++ b/src/graphql/draft.graphql
@@ -11,6 +11,7 @@ type Draft {
     address: String @rename(attribute: "Alamat")
     folder: String @rename(attribute: "Ket")
     file: String @rename(attribute: "DraftFile")
+    attachments: [InboxFile] @rename(attribute: "attachments")
     roleCode: String @rename(attribute: "RoleCode")
     type: DocumentType @belongsTo
     urgency: DocumentUrgency @belongsTo
@@ -26,6 +27,7 @@ input DraftSignatureInput {
 }
 
 #import people.graphql
+#import inboxFile.graphql
 #import documentType.graphql
 #import documentUrgency.graphql
 #import masterClassified.graphql

--- a/src/graphql/inboxFile.graphql
+++ b/src/graphql/inboxFile.graphql
@@ -1,6 +1,7 @@
 type InboxFile {
     id: String @rename(attribute: "Id_dokumen")
     name: String @rename(attribute: "FileName_fake")
+    url: String @rename(attribute: "url")
     inboxDetail: Inbox @belongsTo
     inboxReceivers: [InboxReceiver] @hasMany
     validation: Validation @field(resolver: "App\\GraphQL\\Types\\InboxFileType@validate")


### PR DESCRIPTION
## Overview
- fix: invalid response document file if user used upload file (attachment) on drafting module
- attachments attribute can be multiple files

## Example Query
````
{
  draft(draftId: "XXX", groupId: "XXX") {
    id
    draftId
    draftDetail {
      file
      attachments {
        url
      }
    }
  }
}
````

## Related Task
https://app.clickup.com/t/3bn9t1c

## Evidence
title: fix: invalid response document file if user used upload file (attachment) on drafting module
project: SIDEBAR
participants: @indraprasetya154 @samudra-ajri @fajarhikmal214 